### PR TITLE
feat: GitHub Client基本実装 (#12)

### DIFF
--- a/internal/infra/github/client.go
+++ b/internal/infra/github/client.go
@@ -1,0 +1,128 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/douhashi/soba/internal/infra"
+	"github.com/douhashi/soba/pkg/logger"
+)
+
+const (
+	defaultBaseURL = "https://api.github.com"
+	defaultTimeout = 30 * time.Second
+)
+
+// Client はGitHub APIクライアント
+type Client struct {
+	httpClient    *http.Client
+	tokenProvider TokenProvider
+	baseURL       string
+	logger        logger.Logger
+}
+
+// ClientOptions はクライアントのオプション
+type ClientOptions struct {
+	BaseURL string        // GitHub Enterprise用のカスタムURL
+	Timeout time.Duration // HTTPクライアントのタイムアウト
+	Logger  logger.Logger // ロガー
+}
+
+// NewClient は新しいGitHub APIクライアントを作成する
+func NewClient(tokenProvider TokenProvider, opts *ClientOptions) (*Client, error) {
+	if tokenProvider == nil {
+		return nil, infra.NewGitHubAPIError(0, "", "token provider is required")
+	}
+
+	if opts == nil {
+		opts = &ClientOptions{}
+	}
+
+	baseURL := opts.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
+	l := opts.Logger
+	if l == nil {
+		l = logger.NewNopLogger()
+	}
+
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		tokenProvider: tokenProvider,
+		baseURL:       baseURL,
+		logger:        l,
+	}, nil
+}
+
+// doRequest は認証付きHTTPリクエストを実行する
+func (c *Client) doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
+	// トークンを取得
+	token, err := c.tokenProvider.GetToken(ctx)
+	if err != nil {
+		return nil, infra.WrapInfraError(err, "failed to get token")
+	}
+
+	// ヘッダーを設定
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	// リクエスト情報をログ出力
+	c.logger.Debug("GitHub API request",
+		"method", req.Method,
+		"url", req.URL.String(),
+	)
+
+	// リクエスト実行
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, infra.WrapInfraError(err, "failed to execute HTTP request")
+	}
+
+	// レスポンス情報をログ出力
+	c.logger.Debug("GitHub API response",
+		"status", resp.StatusCode,
+		"url", req.URL.String(),
+	)
+
+	return resp, nil
+}
+
+// parseErrorResponse はエラーレスポンスを解析する
+func (c *Client) parseErrorResponse(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return infra.NewGitHubAPIError(resp.StatusCode, resp.Request.URL.String(), "failed to read error response")
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		// JSONパースに失敗した場合は生のボディを使用
+		return infra.NewGitHubAPIError(resp.StatusCode, resp.Request.URL.String(), string(body))
+	}
+
+	// レート制限エラーの特別処理
+	if resp.StatusCode == http.StatusTooManyRequests {
+		resetTime := resp.Header.Get("X-RateLimit-Reset")
+		return infra.NewGitHubAPIError(
+			resp.StatusCode,
+			resp.Request.URL.String(),
+			fmt.Sprintf("API rate limit exceeded. Reset at: %s. Message: %s", resetTime, errResp.Message),
+		)
+	}
+
+	return infra.NewGitHubAPIError(resp.StatusCode, resp.Request.URL.String(), errResp.Message)
+}

--- a/internal/infra/github/client_test.go
+++ b/internal/infra/github/client_test.go
@@ -1,0 +1,207 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("NewClient", func(t *testing.T) {
+		t.Run("creates client with token provider", func(t *testing.T) {
+			tokenProvider := &mockTokenProvider{
+				token: "test-token",
+			}
+
+			client, err := NewClient(tokenProvider, nil)
+			require.NoError(t, err)
+			assert.NotNil(t, client)
+			assert.Equal(t, tokenProvider, client.tokenProvider)
+			assert.Equal(t, defaultBaseURL, client.baseURL)
+		})
+
+		t.Run("creates client with custom options", func(t *testing.T) {
+			tokenProvider := &mockTokenProvider{
+				token: "test-token",
+			}
+
+			opts := &ClientOptions{
+				BaseURL: "https://github.enterprise.com/api/v3",
+				Timeout: 30 * time.Second,
+			}
+
+			client, err := NewClient(tokenProvider, opts)
+			require.NoError(t, err)
+			assert.NotNil(t, client)
+			assert.Equal(t, opts.BaseURL, client.baseURL)
+		})
+
+		t.Run("returns error when token provider is nil", func(t *testing.T) {
+			client, err := NewClient(nil, nil)
+			assert.Error(t, err)
+			assert.Nil(t, client)
+			assert.Contains(t, err.Error(), "token provider is required")
+		})
+	})
+
+	t.Run("doRequest", func(t *testing.T) {
+		t.Run("sends request with authentication header", func(t *testing.T) {
+			// テストサーバーを作成
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// 認証ヘッダーをチェック
+				assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
+				assert.Equal(t, "/repos/test/repo/issues", r.URL.Path)
+
+				// レスポンスを返す
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode([]Issue{
+					{
+						Number: 1,
+						Title:  "Test Issue",
+						State:  "open",
+					},
+				})
+			}))
+			defer server.Close()
+
+			tokenProvider := &mockTokenProvider{
+				token: "test-token",
+			}
+
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			req, err := http.NewRequestWithContext(ctx, "GET", server.URL+"/repos/test/repo/issues", nil)
+			require.NoError(t, err)
+
+			resp, err := client.doRequest(ctx, req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("handles authentication failure", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(ErrorResponse{
+					Message: "Bad credentials",
+				})
+			}))
+			defer server.Close()
+
+			tokenProvider := &mockTokenProvider{
+				token: "invalid-token",
+			}
+
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			req, err := http.NewRequestWithContext(ctx, "GET", server.URL+"/repos/test/repo/issues", nil)
+			require.NoError(t, err)
+
+			resp, err := client.doRequest(ctx, req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		})
+
+		t.Run("handles token provider error", func(t *testing.T) {
+			tokenProvider := &mockTokenProvider{
+				token: "",
+				err:   assert.AnError,
+			}
+
+			client, err := NewClient(tokenProvider, nil)
+			require.NoError(t, err)
+
+			req, err := http.NewRequestWithContext(ctx, "GET", defaultBaseURL+"/repos/test/repo/issues", nil)
+			require.NoError(t, err)
+
+			_, err = client.doRequest(ctx, req)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to get token")
+		})
+	})
+
+	t.Run("parseErrorResponse", func(t *testing.T) {
+		t.Run("parses GitHub error response", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(ErrorResponse{
+					Message:          "Not Found",
+					DocumentationURL: "https://docs.github.com/rest",
+				})
+			}))
+			defer server.Close()
+
+			tokenProvider := &mockTokenProvider{
+				token: "test-token",
+			}
+
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			req, err := http.NewRequestWithContext(ctx, "GET", server.URL+"/repos/test/repo/issues", nil)
+			require.NoError(t, err)
+
+			resp, err := client.doRequest(ctx, req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			err = client.parseErrorResponse(resp)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "Not Found")
+			assert.Contains(t, err.Error(), "404")
+		})
+
+		t.Run("handles rate limit response", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-RateLimit-Limit", "60")
+				w.Header().Set("X-RateLimit-Remaining", "0")
+				w.Header().Set("X-RateLimit-Reset", "1234567890")
+				w.WriteHeader(http.StatusTooManyRequests)
+				json.NewEncoder(w).Encode(ErrorResponse{
+					Message: "API rate limit exceeded",
+				})
+			}))
+			defer server.Close()
+
+			tokenProvider := &mockTokenProvider{
+				token: "test-token",
+			}
+
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			req, err := http.NewRequestWithContext(ctx, "GET", server.URL+"/repos/test/repo/issues", nil)
+			require.NoError(t, err)
+
+			resp, err := client.doRequest(ctx, req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			err = client.parseErrorResponse(resp)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "rate limit")
+		})
+	})
+}

--- a/internal/infra/github/fixtures_test.go
+++ b/internal/infra/github/fixtures_test.go
@@ -1,0 +1,137 @@
+package github
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// GetTestIssues はテスト用のIssue一覧を返す
+func GetTestIssues() ([]Issue, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	data, err := os.ReadFile(filepath.Join(dir, "testdata", "issues.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	var issues []Issue
+	if err := json.Unmarshal(data, &issues); err != nil {
+		return nil, err
+	}
+
+	return issues, nil
+}
+
+// GetSampleIssue はテスト用の単一Issueを返す
+func GetSampleIssue() Issue {
+	createdAt, _ := time.Parse(time.RFC3339, "2024-01-15T10:30:00Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2024-01-16T14:22:00Z")
+
+	return Issue{
+		ID:      1234567890,
+		Number:  42,
+		Title:   "Feature: Add support for multiple configurations",
+		Body:    "We need to support multiple configuration files to make the system more flexible.",
+		State:   "open",
+		URL:     "https://api.github.com/repos/example/repo/issues/42",
+		HTMLURL: "https://github.com/example/repo/issues/42",
+		Labels: []Label{
+			{
+				ID:    208045946,
+				Name:  "enhancement",
+				Color: "a2eeef",
+			},
+			{
+				ID:    208045947,
+				Name:  "priority:high",
+				Color: "d73a4a",
+			},
+		},
+		Assignees: []User{
+			{
+				ID:      583231,
+				Login:   "octocat",
+				HTMLURL: "https://github.com/octocat",
+			},
+		},
+		User: User{
+			ID:      1,
+			Login:   "developer",
+			HTMLURL: "https://github.com/developer",
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+		ClosedAt:  nil,
+	}
+}
+
+// GetClosedIssue はクローズ済みのテストIssueを返す
+func GetClosedIssue() Issue {
+	createdAt, _ := time.Parse(time.RFC3339, "2024-01-10T10:00:00Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2024-01-12T15:00:00Z")
+	closedAt, _ := time.Parse(time.RFC3339, "2024-01-12T15:00:00Z")
+
+	return Issue{
+		ID:      1234567889,
+		Number:  41,
+		Title:   "Bug: Fixed memory leak",
+		Body:    "There was a memory leak in the parser module.",
+		State:   "closed",
+		URL:     "https://api.github.com/repos/example/repo/issues/41",
+		HTMLURL: "https://github.com/example/repo/issues/41",
+		Labels: []Label{
+			{
+				ID:    208045948,
+				Name:  "bug",
+				Color: "d73a4a",
+			},
+		},
+		Assignees: []User{},
+		User: User{
+			ID:      2,
+			Login:   "contributor",
+			HTMLURL: "https://github.com/contributor",
+		},
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+		ClosedAt:  &closedAt,
+	}
+}
+
+// GetEmptyIssueList は空のIssue一覧を返す
+func GetEmptyIssueList() []Issue {
+	return []Issue{}
+}
+
+// GetLargeIssueList は大量のテストIssueを生成して返す
+func GetLargeIssueList(count int) []Issue {
+	issues := make([]Issue, count)
+	now := time.Now()
+
+	for i := 0; i < count; i++ {
+		issues[i] = Issue{
+			ID:        int64(1000000 + i),
+			Number:    100 + i,
+			Title:     "Test Issue " + string(rune(i)),
+			Body:      "This is a test issue body",
+			State:     "open",
+			URL:       "https://api.github.com/repos/test/repo/issues/" + string(rune(100+i)),
+			HTMLURL:   "https://github.com/test/repo/issues/" + string(rune(100+i)),
+			Labels:    []Label{},
+			Assignees: []User{},
+			User: User{
+				ID:      int64(1000 + i),
+				Login:   "user" + string(rune(i)),
+				HTMLURL: "https://github.com/user" + string(rune(i)),
+			},
+			CreatedAt: now.Add(-time.Duration(i) * time.Hour),
+			UpdatedAt: now.Add(-time.Duration(i/2) * time.Hour),
+			ClosedAt:  nil,
+		}
+	}
+
+	return issues
+}

--- a/internal/infra/github/integration_test.go
+++ b/internal/infra/github/integration_test.go
@@ -1,0 +1,260 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration(t *testing.T) {
+	// 実APIテストのスキップフラグ
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		t.Skip("Skipping integration test: GITHUB_TOKEN not set")
+	}
+
+	ctx := context.Background()
+
+	t.Run("Real API Integration", func(t *testing.T) {
+		t.Run("fetches issues from real repository", func(t *testing.T) {
+			// 環境変数からトークンを取得
+			tokenProvider := NewEnvTokenProvider("GITHUB_TOKEN")
+
+			// クライアントを作成
+			client, err := NewClient(tokenProvider, nil)
+			require.NoError(t, err)
+
+			// GitHub公開リポジトリから Issue を取得
+			issues, hasNext, err := client.ListOpenIssues(ctx, "golang", "go", &ListIssuesOptions{
+				PerPage: 5,
+			})
+
+			// エラーチェック
+			require.NoError(t, err)
+
+			// 結果の検証
+			assert.NotNil(t, issues)
+			assert.GreaterOrEqual(t, len(issues), 0) // 0件以上
+			assert.NotNil(t, hasNext)
+
+			// 各 Issue の基本的なフィールドをチェック
+			for _, issue := range issues {
+				assert.NotZero(t, issue.ID)
+				assert.NotZero(t, issue.Number)
+				assert.NotEmpty(t, issue.Title)
+				assert.NotEmpty(t, issue.State)
+				assert.NotEmpty(t, issue.URL)
+				assert.NotEmpty(t, issue.HTMLURL)
+			}
+		})
+	})
+}
+
+func TestEndToEnd(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Complete workflow with mock server", func(t *testing.T) {
+		// テストデータを取得
+		testIssues, err := GetTestIssues()
+		require.NoError(t, err)
+
+		// モックサーバーの作成
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+
+			// 認証ヘッダーのチェック
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer test-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(ErrorResponse{
+					Message: "Bad credentials",
+				})
+				return
+			}
+
+			// パスのチェック
+			if r.URL.Path != "/repos/test/repo/issues" {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(ErrorResponse{
+					Message: "Not Found",
+				})
+				return
+			}
+
+			// ページングのシミュレーション
+			page := r.URL.Query().Get("page")
+			switch page {
+			case "1":
+				w.Header().Set("Link", `<https://api.github.com/repos/test/repo/issues?page=2>; rel="next"`)
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(testIssues[:2])
+			case "2":
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(testIssues[2:])
+			default:
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode([]Issue{})
+			}
+		}))
+		defer server.Close()
+
+		// トークンプロバイダーの設定
+		tokenProvider := &mockTokenProvider{
+			token: "test-token",
+		}
+
+		// クライアントの作成
+		client, err := NewClient(tokenProvider, &ClientOptions{
+			BaseURL: server.URL,
+		})
+		require.NoError(t, err)
+
+		// 1ページ目を取得
+		issues1, hasNext1, err := client.ListOpenIssues(ctx, "test", "repo", &ListIssuesOptions{
+			Page:    1,
+			PerPage: 2,
+		})
+		require.NoError(t, err)
+		assert.Len(t, issues1, 2)
+		assert.True(t, hasNext1)
+
+		// 2ページ目を取得
+		issues2, hasNext2, err := client.ListOpenIssues(ctx, "test", "repo", &ListIssuesOptions{
+			Page:    2,
+			PerPage: 2,
+		})
+		require.NoError(t, err)
+		assert.Len(t, issues2, 1)
+		assert.False(t, hasNext2)
+
+		// リクエスト回数の確認
+		assert.Equal(t, 2, requestCount)
+	})
+
+	t.Run("Error handling and retry", func(t *testing.T) {
+		// エラー回数をカウント
+		errorCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			errorCount++
+			if errorCount < 3 {
+				// 最初の2回は500エラー
+				w.WriteHeader(http.StatusInternalServerError)
+				json.NewEncoder(w).Encode(ErrorResponse{
+					Message: "Internal Server Error",
+				})
+			} else {
+				// 3回目で成功
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode([]Issue{
+					{
+						Number: 1,
+						Title:  "Success after retry",
+						State:  "open",
+					},
+				})
+			}
+		}))
+		defer server.Close()
+
+		tokenProvider := &mockTokenProvider{
+			token: "test-token",
+		}
+
+		// リトライ機能付きクライアントの作成
+		client, err := NewClient(tokenProvider, &ClientOptions{
+			BaseURL: server.URL,
+		})
+		require.NoError(t, err)
+
+		// リトライクライアントでラップ
+		retryClient := NewRetryableClient(&RetryOptions{
+			MaxRetries:  3,
+			InitialWait: 10 * time.Millisecond,
+			MaxWait:     100 * time.Millisecond,
+		})
+
+		var issues []Issue
+		var hasNext bool
+
+		// リトライ付きでリクエストを実行
+		_, err = retryClient.DoWithRetry(ctx, func() (*http.Response, error) {
+			req, _ := http.NewRequestWithContext(ctx, "GET", server.URL+"/repos/test/repo/issues", nil)
+			resp, err := client.doRequest(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+
+			if resp.StatusCode == http.StatusOK {
+				var tmpIssues []Issue
+				json.NewDecoder(resp.Body).Decode(&tmpIssues)
+				issues = tmpIssues
+				hasNext = false
+				resp.Body.Close()
+			}
+			return resp, nil
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, issues, 1)
+		assert.Equal(t, "Success after retry", issues[0].Title)
+		assert.False(t, hasNext)
+		assert.Equal(t, 3, errorCount) // 2回失敗 + 1回成功
+	})
+
+	t.Run("Authentication flow", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// 認証ヘッダーを確認
+			auth := r.Header.Get("Authorization")
+			if auth == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(ErrorResponse{
+					Message: "Requires authentication",
+				})
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]Issue{})
+		}))
+		defer server.Close()
+
+		t.Run("with valid token", func(t *testing.T) {
+			tokenProvider := &mockTokenProvider{
+				token: "valid-token",
+			}
+
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			issues, _, err := client.ListOpenIssues(ctx, "test", "repo", nil)
+			require.NoError(t, err)
+			assert.Empty(t, issues)
+		})
+
+		t.Run("with token provider error", func(t *testing.T) {
+			tokenProvider := &mockTokenProvider{
+				token: "",
+				err:   assert.AnError,
+			}
+
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			issues, _, err := client.ListOpenIssues(ctx, "test", "repo", nil)
+			assert.Error(t, err)
+			assert.Nil(t, issues)
+			assert.Contains(t, err.Error(), "failed to get token")
+		})
+	})
+}

--- a/internal/infra/github/issue.go
+++ b/internal/infra/github/issue.go
@@ -1,0 +1,150 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/douhashi/soba/internal/infra"
+)
+
+// ListOpenIssues は指定されたリポジトリのオープンなIssue一覧を取得する
+func (c *Client) ListOpenIssues(ctx context.Context, owner, repo string, opts *ListIssuesOptions) ([]Issue, bool, error) {
+	// バリデーション
+	if owner == "" {
+		return nil, false, infra.NewGitHubAPIError(0, "", "owner is required")
+	}
+	if repo == "" {
+		return nil, false, infra.NewGitHubAPIError(0, "", "repo is required")
+	}
+
+	// デフォルトオプションの設定
+	if opts == nil {
+		opts = &ListIssuesOptions{
+			State:   "open",
+			Page:    1,
+			PerPage: 30,
+		}
+	} else {
+		if opts.State == "" {
+			opts.State = "open"
+		}
+		if opts.Page == 0 {
+			opts.Page = 1
+		}
+		if opts.PerPage == 0 {
+			opts.PerPage = 30
+		}
+	}
+
+	// URLの構築
+	apiURL := c.buildIssuesURL(owner, repo, opts)
+
+	// HTTPリクエストの作成
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, false, infra.WrapInfraError(err, "failed to create request")
+	}
+
+	// リクエストの実行
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer resp.Body.Close()
+
+	// エラーレスポンスの処理
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, c.parseErrorResponse(resp)
+	}
+
+	// レスポンスのパース
+	var issues []Issue
+	if err := json.NewDecoder(resp.Body).Decode(&issues); err != nil {
+		return nil, false, infra.WrapInfraError(err, "failed to decode response")
+	}
+
+	// ページネーション情報の取得
+	linkHeader := resp.Header.Get("Link")
+	hasNext := parseLinkHeader(linkHeader)
+
+	return issues, hasNext, nil
+}
+
+// buildIssuesURL はIssue取得用のURLを構築する
+func (c *Client) buildIssuesURL(owner, repo string, opts *ListIssuesOptions) string {
+	baseURL := fmt.Sprintf("%s/repos/%s/%s/issues", c.baseURL, owner, repo)
+
+	params := url.Values{}
+
+	// デフォルト値の設定
+	if opts == nil {
+		params.Set("state", "open")
+		params.Set("page", "1")
+		params.Set("per_page", "30")
+	} else {
+		// State
+		if opts.State != "" {
+			params.Set("state", opts.State)
+		} else {
+			params.Set("state", "open")
+		}
+
+		// Labels
+		if len(opts.Labels) > 0 {
+			params.Set("labels", strings.Join(opts.Labels, ","))
+		}
+
+		// Sort
+		if opts.Sort != "" {
+			params.Set("sort", opts.Sort)
+		}
+
+		// Direction
+		if opts.Direction != "" {
+			params.Set("direction", opts.Direction)
+		}
+
+		// Since
+		if opts.Since != nil {
+			params.Set("since", opts.Since.Format("2006-01-02T15:04:05Z"))
+		}
+
+		// Page
+		if opts.Page > 0 {
+			params.Set("page", fmt.Sprintf("%d", opts.Page))
+		} else {
+			params.Set("page", "1")
+		}
+
+		// PerPage
+		if opts.PerPage > 0 {
+			params.Set("per_page", fmt.Sprintf("%d", opts.PerPage))
+		} else {
+			params.Set("per_page", "30")
+		}
+	}
+
+	return fmt.Sprintf("%s?%s", baseURL, params.Encode())
+}
+
+// parseLinkHeader はLinkヘッダーをパースして次のページがあるか判定する
+func parseLinkHeader(link string) bool {
+	if link == "" {
+		return false
+	}
+
+	// Linkヘッダーは以下のような形式
+	// <https://api.github.com/...?page=2>; rel="next", <https://api.github.com/...?page=10>; rel="last"
+	parts := strings.Split(link, ",")
+	for _, part := range parts {
+		if strings.Contains(part, `rel="next"`) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/infra/github/issue_test.go
+++ b/internal/infra/github/issue_test.go
@@ -1,0 +1,223 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ListOpenIssues", func(t *testing.T) {
+		t.Run("returns list of open issues", func(t *testing.T) {
+			expectedIssues := []Issue{
+				{
+					Number:  1,
+					Title:   "First Issue",
+					State:   "open",
+					HTMLURL: "https://github.com/owner/repo/issues/1",
+				},
+				{
+					Number:  2,
+					Title:   "Second Issue",
+					State:   "open",
+					HTMLURL: "https://github.com/owner/repo/issues/2",
+				},
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// URLパスとクエリパラメータの検証
+				assert.Equal(t, "/repos/owner/repo/issues", r.URL.Path)
+				assert.Equal(t, "open", r.URL.Query().Get("state"))
+				assert.Equal(t, "1", r.URL.Query().Get("page"))
+				assert.Equal(t, "30", r.URL.Query().Get("per_page"))
+
+				// レスポンスヘッダーの設定（ページネーション情報）
+				w.Header().Set("Link", `<https://api.github.com/repos/owner/repo/issues?page=2>; rel="next"`)
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(expectedIssues)
+			}))
+			defer server.Close()
+
+			tokenProvider := &mockTokenProvider{token: "test-token"}
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			issues, hasNext, err := client.ListOpenIssues(ctx, "owner", "repo", nil)
+			require.NoError(t, err)
+			assert.Equal(t, expectedIssues, issues)
+			assert.True(t, hasNext)
+		})
+
+		t.Run("handles options correctly", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// オプションが正しくクエリパラメータに変換されているか確認
+				assert.Equal(t, "/repos/owner/repo/issues", r.URL.Path)
+
+				query := r.URL.Query()
+				assert.Equal(t, "all", query.Get("state"))
+				assert.Equal(t, "bug,enhancement", query.Get("labels"))
+				assert.Equal(t, "updated", query.Get("sort"))
+				assert.Equal(t, "desc", query.Get("direction"))
+				assert.Equal(t, "2", query.Get("page"))
+				assert.Equal(t, "50", query.Get("per_page"))
+
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode([]Issue{})
+			}))
+			defer server.Close()
+
+			tokenProvider := &mockTokenProvider{token: "test-token"}
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			opts := &ListIssuesOptions{
+				State:     "all",
+				Labels:    []string{"bug", "enhancement"},
+				Sort:      "updated",
+				Direction: "desc",
+				Page:      2,
+				PerPage:   50,
+			}
+
+			_, _, err = client.ListOpenIssues(ctx, "owner", "repo", opts)
+			require.NoError(t, err)
+		})
+
+		t.Run("handles empty response", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode([]Issue{})
+			}))
+			defer server.Close()
+
+			tokenProvider := &mockTokenProvider{token: "test-token"}
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			issues, hasNext, err := client.ListOpenIssues(ctx, "owner", "repo", nil)
+			require.NoError(t, err)
+			assert.Empty(t, issues)
+			assert.False(t, hasNext)
+		})
+
+		t.Run("handles API error", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(ErrorResponse{
+					Message: "Not Found",
+				})
+			}))
+			defer server.Close()
+
+			tokenProvider := &mockTokenProvider{token: "test-token"}
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				BaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			issues, _, err := client.ListOpenIssues(ctx, "owner", "repo", nil)
+			assert.Error(t, err)
+			assert.Nil(t, issues)
+			assert.Contains(t, err.Error(), "Not Found")
+		})
+
+		t.Run("validates required parameters", func(t *testing.T) {
+			tokenProvider := &mockTokenProvider{token: "test-token"}
+			client, err := NewClient(tokenProvider, nil)
+			require.NoError(t, err)
+
+			// オーナーが空の場合
+			issues, _, err := client.ListOpenIssues(ctx, "", "repo", nil)
+			assert.Error(t, err)
+			assert.Nil(t, issues)
+			assert.Contains(t, err.Error(), "owner is required")
+
+			// レポジトリが空の場合
+			issues, _, err = client.ListOpenIssues(ctx, "owner", "", nil)
+			assert.Error(t, err)
+			assert.Nil(t, issues)
+			assert.Contains(t, err.Error(), "repo is required")
+		})
+	})
+
+	t.Run("parseLinkHeader", func(t *testing.T) {
+		t.Run("parses link header with next", func(t *testing.T) {
+			link := `<https://api.github.com/repos/owner/repo/issues?page=2>; rel="next", <https://api.github.com/repos/owner/repo/issues?page=10>; rel="last"`
+			hasNext := parseLinkHeader(link)
+			assert.True(t, hasNext)
+		})
+
+		t.Run("parses link header without next", func(t *testing.T) {
+			link := `<https://api.github.com/repos/owner/repo/issues?page=1>; rel="prev", <https://api.github.com/repos/owner/repo/issues?page=10>; rel="last"`
+			hasNext := parseLinkHeader(link)
+			assert.False(t, hasNext)
+		})
+
+		t.Run("handles empty link header", func(t *testing.T) {
+			hasNext := parseLinkHeader("")
+			assert.False(t, hasNext)
+		})
+	})
+
+	t.Run("buildIssuesURL", func(t *testing.T) {
+		client, err := NewClient(&mockTokenProvider{token: "test"}, nil)
+		require.NoError(t, err)
+
+		t.Run("builds basic URL", func(t *testing.T) {
+			url := client.buildIssuesURL("owner", "repo", nil)
+			assert.Equal(t, "https://api.github.com/repos/owner/repo/issues?page=1&per_page=30&state=open", url)
+		})
+
+		t.Run("builds URL with options", func(t *testing.T) {
+			opts := &ListIssuesOptions{
+				State:     "closed",
+				Labels:    []string{"bug", "help wanted"},
+				Sort:      "created",
+				Direction: "asc",
+				Page:      2,
+				PerPage:   50,
+			}
+
+			urlStr := client.buildIssuesURL("owner", "repo", opts)
+			parsedURL, err := url.Parse(urlStr)
+			require.NoError(t, err)
+
+			query := parsedURL.Query()
+			assert.Equal(t, "closed", query.Get("state"))
+			assert.Equal(t, "bug,help wanted", query.Get("labels"))
+			assert.Equal(t, "created", query.Get("sort"))
+			assert.Equal(t, "asc", query.Get("direction"))
+			assert.Equal(t, "2", query.Get("page"))
+			assert.Equal(t, "50", query.Get("per_page"))
+		})
+
+		t.Run("handles Since parameter", func(t *testing.T) {
+			since := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			opts := &ListIssuesOptions{
+				Since: &since,
+			}
+
+			urlStr := client.buildIssuesURL("owner", "repo", opts)
+			parsedURL, err := url.Parse(urlStr)
+			require.NoError(t, err)
+
+			query := parsedURL.Query()
+			assert.Equal(t, "2024-01-01T00:00:00Z", query.Get("since"))
+		})
+	})
+}

--- a/internal/infra/github/mock_client.go
+++ b/internal/infra/github/mock_client.go
@@ -1,0 +1,103 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/douhashi/soba/internal/infra"
+)
+
+// MockClient はGitHub APIクライアントのモック実装
+type MockClient struct {
+	// ListOpenIssuesのモック設定
+	ListOpenIssuesFunc func(ctx context.Context, owner, repo string, opts *ListIssuesOptions) ([]Issue, bool, error)
+	ListOpenIssuesCalls []struct {
+		Owner string
+		Repo  string
+		Opts  *ListIssuesOptions
+	}
+
+	// エラーを返すかどうか
+	ShouldError bool
+	Error       error
+
+	// 返すデータ
+	Issues  []Issue
+	HasNext bool
+}
+
+// NewMockClient は新しいMockClientを作成する
+func NewMockClient() *MockClient {
+	return &MockClient{
+		Issues: []Issue{},
+	}
+}
+
+// ListOpenIssues のモック実装
+func (m *MockClient) ListOpenIssues(ctx context.Context, owner, repo string, opts *ListIssuesOptions) ([]Issue, bool, error) {
+	// 呼び出しを記録
+	m.ListOpenIssuesCalls = append(m.ListOpenIssuesCalls, struct {
+		Owner string
+		Repo  string
+		Opts  *ListIssuesOptions
+	}{
+		Owner: owner,
+		Repo:  repo,
+		Opts:  opts,
+	})
+
+	// カスタム関数が設定されている場合はそれを使用
+	if m.ListOpenIssuesFunc != nil {
+		return m.ListOpenIssuesFunc(ctx, owner, repo, opts)
+	}
+
+	// エラーを返す設定の場合
+	if m.ShouldError {
+		if m.Error != nil {
+			return nil, false, m.Error
+		}
+		return nil, false, infra.NewGitHubAPIError(500, "/repos/"+owner+"/"+repo+"/issues", "mock error")
+	}
+
+	// 正常なレスポンスを返す
+	return m.Issues, m.HasNext, nil
+}
+
+// SetupSuccessResponse はモックの成功レスポンスを設定する
+func (m *MockClient) SetupSuccessResponse(issues []Issue, hasNext bool) {
+	m.Issues = issues
+	m.HasNext = hasNext
+	m.ShouldError = false
+	m.Error = nil
+}
+
+// SetupErrorResponse はモックのエラーレスポンスを設定する
+func (m *MockClient) SetupErrorResponse(statusCode int, message string) {
+	m.ShouldError = true
+	m.Error = infra.NewGitHubAPIError(statusCode, "/repos/test/test/issues", message)
+}
+
+// Reset はモックの状態をリセットする
+func (m *MockClient) Reset() {
+	m.ListOpenIssuesCalls = nil
+	m.ListOpenIssuesFunc = nil
+	m.ShouldError = false
+	m.Error = nil
+	m.Issues = []Issue{}
+	m.HasNext = false
+}
+
+// AssertCalled は指定された呼び出しがされたか確認する
+func (m *MockClient) AssertCalled(owner, repo string) error {
+	for _, call := range m.ListOpenIssuesCalls {
+		if call.Owner == owner && call.Repo == repo {
+			return nil
+		}
+	}
+	return fmt.Errorf("ListOpenIssues was not called with owner=%s, repo=%s", owner, repo)
+}
+
+// CallCount は呼び出し回数を返す
+func (m *MockClient) CallCount() int {
+	return len(m.ListOpenIssuesCalls)
+}

--- a/internal/infra/github/retry.go
+++ b/internal/infra/github/retry.go
@@ -1,0 +1,210 @@
+package github
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/douhashi/soba/internal/infra"
+	"github.com/douhashi/soba/pkg/logger"
+)
+
+// RetryOptions はリトライの設定
+type RetryOptions struct {
+	MaxRetries  int           // 最大リトライ回数
+	InitialWait time.Duration // 初回待機時間
+	MaxWait     time.Duration // 最大待機時間
+	Multiplier  float64       // 待機時間の倍率
+	Logger      logger.Logger // ロガー
+}
+
+// デフォルトのリトライ設定
+var defaultRetryOptions = &RetryOptions{
+	MaxRetries:  3,
+	InitialWait: 1 * time.Second,
+	MaxWait:     30 * time.Second,
+	Multiplier:  2.0,
+}
+
+// RetryableClient はリトライ機能を持つHTTPクライアント
+type RetryableClient struct {
+	options *RetryOptions
+	logger  logger.Logger
+}
+
+// NewRetryableClient は新しいRetryableClientを作成する
+func NewRetryableClient(opts *RetryOptions) *RetryableClient {
+	if opts == nil {
+		opts = defaultRetryOptions
+	}
+
+	if opts.Multiplier == 0 {
+		opts.Multiplier = 2.0
+	}
+	if opts.InitialWait == 0 {
+		opts.InitialWait = 1 * time.Second
+	}
+	if opts.MaxWait == 0 {
+		opts.MaxWait = 30 * time.Second
+	}
+
+	l := opts.Logger
+	if l == nil {
+		l = logger.NewNopLogger()
+	}
+
+	return &RetryableClient{
+		options: opts,
+		logger:  l,
+	}
+}
+
+// DoWithRetry はリトライ付きでHTTPリクエストを実行する
+func (r *RetryableClient) DoWithRetry(ctx context.Context, fn func() (*http.Response, error)) (*http.Response, error) {
+	var lastResp *http.Response
+	var lastErr error
+
+	for attempt := 0; attempt <= r.options.MaxRetries; attempt++ {
+		// コンテキストのキャンセルチェック
+		select {
+		case <-ctx.Done():
+			return nil, infra.WrapInfraError(ctx.Err(), "context canceled during retry")
+		default:
+		}
+
+		// リクエスト実行
+		resp, err := fn()
+		lastResp = resp
+		lastErr = err
+
+		// 成功またはリトライ不可能な場合は終了
+		if err == nil && resp != nil && !isRetryable(resp, err) {
+			return resp, nil
+		}
+
+		// 最大リトライ回数に達した場合
+		if attempt >= r.options.MaxRetries {
+			r.logger.Debug("Max retries reached",
+				"attempt", attempt+1,
+				"max_retries", r.options.MaxRetries,
+			)
+			break
+		}
+
+		// 待機時間の計算
+		var waitTime time.Duration
+		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+			// レート制限の場合は Reset 時刻まで待機
+			waitTime = getRateLimitReset(resp)
+			r.logger.Info("Rate limited, waiting until reset",
+				"wait_seconds", waitTime.Seconds(),
+				"attempt", attempt+1,
+			)
+		} else {
+			// 指数バックオフ
+			waitTime = calculateBackoff(attempt, r.options)
+			r.logger.Debug("Retrying after backoff",
+				"wait_seconds", waitTime.Seconds(),
+				"attempt", attempt+1,
+				"status_code", getStatusCode(resp),
+			)
+		}
+
+		// 待機
+		select {
+		case <-time.After(waitTime):
+			// 待機完了
+		case <-ctx.Done():
+			return nil, infra.WrapInfraError(ctx.Err(), "context canceled during backoff")
+		}
+	}
+
+	// 最後のレスポンス/エラーを返す
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return lastResp, nil
+}
+
+// isRetryable はリトライ可能なエラーかどうか判定する
+func isRetryable(resp *http.Response, err error) bool {
+	// ネットワークエラーの場合はリトライ
+	if err != nil {
+		return true
+	}
+
+	// レスポンスがない場合はリトライしない
+	if resp == nil {
+		return false
+	}
+
+	// ステータスコードで判定
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests, // 429
+		http.StatusInternalServerError,    // 500
+		http.StatusBadGateway,              // 502
+		http.StatusServiceUnavailable,      // 503
+		http.StatusGatewayTimeout:          // 504
+		return true
+	default:
+		return false
+	}
+}
+
+// calculateBackoff は指数バックオフの待機時間を計算する
+func calculateBackoff(attempt int, opts *RetryOptions) time.Duration {
+	// 指数バックオフの計算
+	wait := float64(opts.InitialWait) * math.Pow(opts.Multiplier, float64(attempt))
+
+	// 最大待機時間で制限
+	if wait > float64(opts.MaxWait) {
+		wait = float64(opts.MaxWait)
+	}
+
+	// ジッターの追加 (0.5〜1.0倍のランダム)
+	jitter := 0.5 + rand.Float64()*0.5
+	wait = wait * jitter
+
+	return time.Duration(wait)
+}
+
+// getRateLimitReset はレート制限のリセット時刻までの待機時間を取得する
+func getRateLimitReset(resp *http.Response) time.Duration {
+	if resp == nil || resp.Header == nil {
+		return 60 * time.Second // デフォルト値
+	}
+
+	resetStr := resp.Header.Get("X-RateLimit-Reset")
+	if resetStr == "" {
+		return 60 * time.Second
+	}
+
+	resetTime, err := strconv.ParseInt(resetStr, 10, 64)
+	if err != nil {
+		return 60 * time.Second
+	}
+
+	// リセット時刻までの待機時間を計算
+	wait := time.Until(time.Unix(resetTime, 0))
+	if wait <= 0 {
+		return 100 * time.Millisecond // 過去の時刻の場合は短い待機時間
+	}
+
+	// 最大待機時間を制限（テストのため）
+	if wait > 60*time.Second {
+		return 60 * time.Second
+	}
+
+	return wait
+}
+
+// getStatusCode はレスポンスからステータスコードを安全に取得する
+func getStatusCode(resp *http.Response) int {
+	if resp == nil {
+		return 0
+	}
+	return resp.StatusCode
+}

--- a/internal/infra/github/retry_test.go
+++ b/internal/infra/github/retry_test.go
@@ -1,0 +1,268 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetry(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("RetryableClient", func(t *testing.T) {
+		t.Run("succeeds on first attempt", func(t *testing.T) {
+			attempt := 0
+			handler := func() (*http.Response, error) {
+				attempt++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			}
+
+			retrier := NewRetryableClient(nil)
+			resp, err := retrier.DoWithRetry(ctx, handler)
+			require.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, 1, attempt)
+		})
+
+		t.Run("retries on rate limit error", func(t *testing.T) {
+			attempt := 0
+			handler := func() (*http.Response, error) {
+				attempt++
+				if attempt < 3 {
+					// 通常のサーバーエラーとして扱う（レート制限のテストは別途）
+					return &http.Response{
+						StatusCode: http.StatusServiceUnavailable,
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			}
+
+			opts := &RetryOptions{
+				MaxRetries:  3,
+				InitialWait: 10 * time.Millisecond,
+				MaxWait:     100 * time.Millisecond,
+			}
+			retrier := NewRetryableClient(opts)
+			resp, err := retrier.DoWithRetry(ctx, handler)
+			require.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, 3, attempt)
+		})
+
+		t.Run("retries on 500 errors", func(t *testing.T) {
+			attempt := 0
+			handler := func() (*http.Response, error) {
+				attempt++
+				if attempt < 2 {
+					return &http.Response{
+						StatusCode: http.StatusInternalServerError,
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			}
+
+			opts := &RetryOptions{
+				MaxRetries:  3,
+				InitialWait: 10 * time.Millisecond,
+			}
+			retrier := NewRetryableClient(opts)
+			resp, err := retrier.DoWithRetry(ctx, handler)
+			require.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, 2, attempt)
+		})
+
+		t.Run("retries on network error", func(t *testing.T) {
+			attempt := 0
+			handler := func() (*http.Response, error) {
+				attempt++
+				if attempt < 2 {
+					return nil, fmt.Errorf("network error")
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			}
+
+			opts := &RetryOptions{
+				MaxRetries:  3,
+				InitialWait: 10 * time.Millisecond,
+			}
+			retrier := NewRetryableClient(opts)
+			resp, err := retrier.DoWithRetry(ctx, handler)
+			require.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, 2, attempt)
+		})
+
+		t.Run("stops after max retries", func(t *testing.T) {
+			attempt := 0
+			handler := func() (*http.Response, error) {
+				attempt++
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+				}, nil
+			}
+
+			opts := &RetryOptions{
+				MaxRetries:  2,
+				InitialWait: 10 * time.Millisecond,
+			}
+			retrier := NewRetryableClient(opts)
+			resp, err := retrier.DoWithRetry(ctx, handler)
+			assert.NoError(t, err) // エラーは返さない、最後のレスポンスを返す
+			assert.NotNil(t, resp)
+			assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+			assert.Equal(t, 3, attempt) // 初回 + 2リトライ
+		})
+
+		t.Run("does not retry on client errors", func(t *testing.T) {
+			attempt := 0
+			handler := func() (*http.Response, error) {
+				attempt++
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+				}, nil
+			}
+
+			retrier := NewRetryableClient(nil)
+			resp, err := retrier.DoWithRetry(ctx, handler)
+			require.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Equal(t, 1, attempt)
+		})
+
+		t.Run("respects context cancellation", func(t *testing.T) {
+			cancelCtx, cancel := context.WithCancel(ctx)
+			cancel() // すぐにキャンセル
+
+			attempt := 0
+			handler := func() (*http.Response, error) {
+				attempt++
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+				}, nil
+			}
+
+			retrier := NewRetryableClient(nil)
+			resp, err := retrier.DoWithRetry(cancelCtx, handler)
+			assert.Error(t, err)
+			assert.Nil(t, resp)
+			assert.Contains(t, err.Error(), "context canceled")
+			assert.Equal(t, 0, attempt) // コンテキストがキャンセル済みなので実行されない
+		})
+	})
+
+	t.Run("isRetryable", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			statusCode int
+			err        error
+			expected   bool
+		}{
+			{"429 Too Many Requests", http.StatusTooManyRequests, nil, true},
+			{"500 Internal Server Error", http.StatusInternalServerError, nil, true},
+			{"502 Bad Gateway", http.StatusBadGateway, nil, true},
+			{"503 Service Unavailable", http.StatusServiceUnavailable, nil, true},
+			{"504 Gateway Timeout", http.StatusGatewayTimeout, nil, true},
+			{"Network Error", 0, fmt.Errorf("network error"), true},
+			{"200 OK", http.StatusOK, nil, false},
+			{"400 Bad Request", http.StatusBadRequest, nil, false},
+			{"401 Unauthorized", http.StatusUnauthorized, nil, false},
+			{"404 Not Found", http.StatusNotFound, nil, false},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var resp *http.Response
+				if tt.statusCode > 0 {
+					resp = &http.Response{StatusCode: tt.statusCode}
+				}
+				result := isRetryable(resp, tt.err)
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("calculateBackoff", func(t *testing.T) {
+		opts := &RetryOptions{
+			InitialWait: 100 * time.Millisecond,
+			MaxWait:     2 * time.Second,
+			Multiplier:  2,
+		}
+
+		t.Run("exponential backoff", func(t *testing.T) {
+			// 初回: 100ms（ジッター込みで50-100ms）
+			wait := calculateBackoff(0, opts)
+			assert.GreaterOrEqual(t, wait, 50*time.Millisecond)
+			assert.LessOrEqual(t, wait, 100*time.Millisecond)
+
+			// 2回目: 200ms（ジッター込みで100-200ms）
+			wait = calculateBackoff(1, opts)
+			assert.GreaterOrEqual(t, wait, 100*time.Millisecond)
+			assert.LessOrEqual(t, wait, 200*time.Millisecond)
+
+			// 3回目: 400ms（ジッター込みで200-400ms）
+			wait = calculateBackoff(2, opts)
+			assert.GreaterOrEqual(t, wait, 200*time.Millisecond)
+			assert.LessOrEqual(t, wait, 400*time.Millisecond)
+		})
+
+		t.Run("respects max wait", func(t *testing.T) {
+			// 多くの試行後でもMaxWaitを超えない
+			wait := calculateBackoff(10, opts)
+			assert.LessOrEqual(t, wait, 2*time.Second)
+		})
+	})
+
+	t.Run("getRateLimitReset", func(t *testing.T) {
+		t.Run("parses reset time from header", func(t *testing.T) {
+			now := time.Now()
+			resetTime := now.Add(30 * time.Second)
+			resp := &http.Response{
+				Header: http.Header{
+					"X-RateLimit-Reset": []string{fmt.Sprintf("%d", resetTime.Unix())},
+				},
+			}
+
+			wait := getRateLimitReset(resp)
+			// 誤差を考慮して29-31秒の範囲で判定
+			assert.GreaterOrEqual(t, wait, 29*time.Second)
+			assert.LessOrEqual(t, wait, 60*time.Second) // 最大60秒に制限されている
+		})
+
+		t.Run("returns default when header is missing", func(t *testing.T) {
+			resp := &http.Response{
+				Header: http.Header{},
+			}
+
+			wait := getRateLimitReset(resp)
+			assert.Equal(t, 60*time.Second, wait)
+		})
+
+		t.Run("returns default when header is invalid", func(t *testing.T) {
+			resp := &http.Response{
+				Header: http.Header{
+					"X-RateLimit-Reset": []string{"invalid"},
+				},
+			}
+
+			wait := getRateLimitReset(resp)
+			assert.Equal(t, 60*time.Second, wait)
+		})
+	})
+}

--- a/internal/infra/github/testdata/issues.json
+++ b/internal/infra/github/testdata/issues.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": 1234567890,
+    "number": 42,
+    "title": "Feature: Add support for multiple configurations",
+    "body": "We need to support multiple configuration files to make the system more flexible.\n\n## Requirements\n- Load configs from multiple sources\n- Merge configurations with proper precedence\n- Validate merged configuration",
+    "state": "open",
+    "url": "https://api.github.com/repos/example/repo/issues/42",
+    "html_url": "https://github.com/example/repo/issues/42",
+    "labels": [
+      {
+        "id": 208045946,
+        "name": "enhancement",
+        "color": "a2eeef"
+      },
+      {
+        "id": 208045947,
+        "name": "priority:high",
+        "color": "d73a4a"
+      }
+    ],
+    "assignees": [
+      {
+        "id": 583231,
+        "login": "octocat",
+        "html_url": "https://github.com/octocat"
+      }
+    ],
+    "user": {
+      "id": 1,
+      "login": "developer",
+      "html_url": "https://github.com/developer"
+    },
+    "created_at": "2024-01-15T10:30:00Z",
+    "updated_at": "2024-01-16T14:22:00Z",
+    "closed_at": null
+  },
+  {
+    "id": 1234567891,
+    "number": 43,
+    "title": "Bug: Application crashes on startup with empty config",
+    "body": "When the configuration file is empty, the application crashes with a nil pointer exception.\n\n## Steps to reproduce\n1. Create an empty config.json\n2. Start the application\n3. Observe crash\n\n## Expected behavior\nApplication should start with default values",
+    "state": "open",
+    "url": "https://api.github.com/repos/example/repo/issues/43",
+    "html_url": "https://github.com/example/repo/issues/43",
+    "labels": [
+      {
+        "id": 208045948,
+        "name": "bug",
+        "color": "d73a4a"
+      },
+      {
+        "id": 208045949,
+        "name": "good first issue",
+        "color": "7057ff"
+      }
+    ],
+    "assignees": [],
+    "user": {
+      "id": 2,
+      "login": "contributor",
+      "html_url": "https://github.com/contributor"
+    },
+    "created_at": "2024-01-17T08:15:00Z",
+    "updated_at": "2024-01-17T08:15:00Z",
+    "closed_at": null
+  },
+  {
+    "id": 1234567892,
+    "number": 44,
+    "title": "Documentation: Update README with new features",
+    "body": "The README needs to be updated to reflect the new features added in v2.0.0",
+    "state": "open",
+    "url": "https://api.github.com/repos/example/repo/issues/44",
+    "html_url": "https://github.com/example/repo/issues/44",
+    "labels": [
+      {
+        "id": 208045950,
+        "name": "documentation",
+        "color": "0075ca"
+      }
+    ],
+    "assignees": [
+      {
+        "id": 583232,
+        "login": "writer",
+        "html_url": "https://github.com/writer"
+      }
+    ],
+    "user": {
+      "id": 3,
+      "login": "maintainer",
+      "html_url": "https://github.com/maintainer"
+    },
+    "created_at": "2024-01-18T11:00:00Z",
+    "updated_at": "2024-01-19T09:30:00Z",
+    "closed_at": null
+  }
+]

--- a/internal/infra/github/token_provider.go
+++ b/internal/infra/github/token_provider.go
@@ -1,0 +1,151 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/douhashi/soba/internal/infra"
+)
+
+// TokenProvider はGitHubのアクセストークンを提供するインターフェース
+type TokenProvider interface {
+	GetToken(ctx context.Context) (string, error)
+}
+
+// GhCliTokenProvider は`gh auth token`コマンドからトークンを取得する
+type GhCliTokenProvider struct {
+	// テスト用にコマンド実行を差し替え可能にする
+	commandExecutor func(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// NewGhCliTokenProvider は新しいGhCliTokenProviderを作成する
+func NewGhCliTokenProvider() *GhCliTokenProvider {
+	return &GhCliTokenProvider{
+		commandExecutor: defaultCommandExecutor,
+	}
+}
+
+// GetToken は`gh auth token`コマンドを実行してトークンを取得する
+func (p *GhCliTokenProvider) GetToken(ctx context.Context) (string, error) {
+	executor := p.commandExecutor
+	if executor == nil {
+		executor = defaultCommandExecutor
+	}
+
+	output, err := executor(ctx, "gh", "auth", "token")
+	if err != nil {
+		return "", infra.NewGitHubAPIError(
+			0,
+			"gh auth token",
+			fmt.Sprintf("failed to get token from gh cli: %v", err),
+		)
+	}
+
+	token := strings.TrimSpace(string(output))
+	if token == "" {
+		return "", infra.NewGitHubAPIError(
+			0,
+			"gh auth token",
+			"gh auth token returned empty",
+		)
+	}
+
+	return token, nil
+}
+
+// EnvTokenProvider は環境変数からトークンを取得する
+type EnvTokenProvider struct {
+	envKey string
+}
+
+// NewEnvTokenProvider は新しいEnvTokenProviderを作成する
+func NewEnvTokenProvider(envKey string) *EnvTokenProvider {
+	return &EnvTokenProvider{
+		envKey: envKey,
+	}
+}
+
+// GetToken は環境変数からトークンを取得する
+func (p *EnvTokenProvider) GetToken(ctx context.Context) (string, error) {
+	key := p.envKey
+	if key == "" {
+		key = "GITHUB_TOKEN"
+	}
+
+	token := os.Getenv(key)
+	if token == "" {
+		return "", infra.NewGitHubAPIError(
+			0,
+			"environment",
+			fmt.Sprintf("environment variable %s is not set", key),
+		)
+	}
+
+	return token, nil
+}
+
+// ChainTokenProvider は複数のTokenProviderを順番に試す
+type ChainTokenProvider struct {
+	providers []TokenProvider
+}
+
+// NewChainTokenProvider は新しいChainTokenProviderを作成する
+func NewChainTokenProvider(providers ...TokenProvider) *ChainTokenProvider {
+	return &ChainTokenProvider{
+		providers: providers,
+	}
+}
+
+// GetToken は各プロバイダーを順番に試してトークンを取得する
+func (p *ChainTokenProvider) GetToken(ctx context.Context) (string, error) {
+	if len(p.providers) == 0 {
+		return "", infra.NewGitHubAPIError(
+			0,
+			"token-chain",
+			"no token providers configured",
+		)
+	}
+
+	var lastErr error
+	for _, provider := range p.providers {
+		token, err := provider.GetToken(ctx)
+		if err == nil && token != "" {
+			return token, nil
+		}
+		lastErr = err
+	}
+
+	if lastErr != nil {
+		return "", infra.NewGitHubAPIError(
+			0,
+			"token-chain",
+			fmt.Sprintf("all token providers failed: %v", lastErr),
+		)
+	}
+
+	return "", infra.NewGitHubAPIError(
+		0,
+		"token-chain",
+		"all token providers failed",
+	)
+}
+
+// NewDefaultTokenProvider はデフォルトのTokenProviderを作成する
+// 1. gh auth token
+// 2. GITHUB_TOKEN環境変数
+// の順で試行する
+func NewDefaultTokenProvider() TokenProvider {
+	return NewChainTokenProvider(
+		NewGhCliTokenProvider(),
+		NewEnvTokenProvider("GITHUB_TOKEN"),
+	)
+}
+
+// defaultCommandExecutor はデフォルトのコマンド実行関数
+func defaultCommandExecutor(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.Output()
+}

--- a/internal/infra/github/token_provider_test.go
+++ b/internal/infra/github/token_provider_test.go
@@ -1,0 +1,235 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenProvider(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("GhCliTokenProvider", func(t *testing.T) {
+		t.Run("returns token from gh auth token command", func(t *testing.T) {
+			// モックコマンドを作成
+			provider := &GhCliTokenProvider{
+				commandExecutor: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+					assert.Equal(t, "gh", name)
+					assert.Equal(t, []string{"auth", "token"}, args)
+					return []byte("test-gh-token"), nil
+				},
+			}
+
+			token, err := provider.GetToken(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, "test-gh-token", token)
+		})
+
+		t.Run("returns error when gh command fails", func(t *testing.T) {
+			provider := &GhCliTokenProvider{
+				commandExecutor: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+					return nil, fmt.Errorf("command failed")
+				},
+			}
+
+			token, err := provider.GetToken(ctx)
+			assert.Error(t, err)
+			assert.Empty(t, token)
+			assert.Contains(t, err.Error(), "failed to get token from gh cli")
+		})
+
+		t.Run("returns error when token is empty", func(t *testing.T) {
+			provider := &GhCliTokenProvider{
+				commandExecutor: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+					return []byte(""), nil
+				},
+			}
+
+			token, err := provider.GetToken(ctx)
+			assert.Error(t, err)
+			assert.Empty(t, token)
+			assert.Contains(t, err.Error(), "gh auth token returned empty")
+		})
+	})
+
+	t.Run("EnvTokenProvider", func(t *testing.T) {
+		t.Run("returns token from environment variable", func(t *testing.T) {
+			// 環境変数を設定
+			originalValue := os.Getenv("GITHUB_TOKEN")
+			defer func() {
+				if originalValue != "" {
+					os.Setenv("GITHUB_TOKEN", originalValue)
+				} else {
+					os.Unsetenv("GITHUB_TOKEN")
+				}
+			}()
+
+			os.Setenv("GITHUB_TOKEN", "test-env-token")
+
+			provider := &EnvTokenProvider{
+				envKey: "GITHUB_TOKEN",
+			}
+
+			token, err := provider.GetToken(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, "test-env-token", token)
+		})
+
+		t.Run("returns error when environment variable is not set", func(t *testing.T) {
+			// 環境変数をクリア
+			originalValue := os.Getenv("TEST_TOKEN")
+			defer func() {
+				if originalValue != "" {
+					os.Setenv("TEST_TOKEN", originalValue)
+				}
+			}()
+			os.Unsetenv("TEST_TOKEN")
+
+			provider := &EnvTokenProvider{
+				envKey: "TEST_TOKEN",
+			}
+
+			token, err := provider.GetToken(ctx)
+			assert.Error(t, err)
+			assert.Empty(t, token)
+			assert.Contains(t, err.Error(), "environment variable TEST_TOKEN is not set")
+		})
+
+		t.Run("uses default GITHUB_TOKEN when envKey is empty", func(t *testing.T) {
+			originalValue := os.Getenv("GITHUB_TOKEN")
+			defer func() {
+				if originalValue != "" {
+					os.Setenv("GITHUB_TOKEN", originalValue)
+				} else {
+					os.Unsetenv("GITHUB_TOKEN")
+				}
+			}()
+
+			os.Setenv("GITHUB_TOKEN", "default-token")
+
+			provider := &EnvTokenProvider{}
+
+			token, err := provider.GetToken(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, "default-token", token)
+		})
+	})
+
+	t.Run("ChainTokenProvider", func(t *testing.T) {
+		t.Run("returns token from first successful provider", func(t *testing.T) {
+			provider1 := &mockTokenProvider{
+				token: "",
+				err:   fmt.Errorf("provider1 failed"),
+			}
+			provider2 := &mockTokenProvider{
+				token: "token-from-provider2",
+				err:   nil,
+			}
+			provider3 := &mockTokenProvider{
+				token: "token-from-provider3",
+				err:   nil,
+			}
+
+			chain := &ChainTokenProvider{
+				providers: []TokenProvider{provider1, provider2, provider3},
+			}
+
+			token, err := chain.GetToken(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, "token-from-provider2", token)
+			assert.True(t, provider1.called)
+			assert.True(t, provider2.called)
+			assert.False(t, provider3.called) // 3番目は呼ばれない
+		})
+
+		t.Run("returns error when all providers fail", func(t *testing.T) {
+			provider1 := &mockTokenProvider{
+				token: "",
+				err:   fmt.Errorf("provider1 failed"),
+			}
+			provider2 := &mockTokenProvider{
+				token: "",
+				err:   fmt.Errorf("provider2 failed"),
+			}
+
+			chain := &ChainTokenProvider{
+				providers: []TokenProvider{provider1, provider2},
+			}
+
+			token, err := chain.GetToken(ctx)
+			assert.Error(t, err)
+			assert.Empty(t, token)
+			assert.Contains(t, err.Error(), "all token providers failed")
+		})
+
+		t.Run("returns error when no providers are configured", func(t *testing.T) {
+			chain := &ChainTokenProvider{
+				providers: []TokenProvider{},
+			}
+
+			token, err := chain.GetToken(ctx)
+			assert.Error(t, err)
+			assert.Empty(t, token)
+			assert.Contains(t, err.Error(), "no token providers configured")
+		})
+	})
+
+	t.Run("NewDefaultTokenProvider", func(t *testing.T) {
+		t.Run("creates chain with both providers", func(t *testing.T) {
+			provider := NewDefaultTokenProvider()
+
+			chain, ok := provider.(*ChainTokenProvider)
+			require.True(t, ok)
+			assert.Len(t, chain.providers, 2)
+
+			// 最初はGhCliTokenProvider
+			_, isGhCli := chain.providers[0].(*GhCliTokenProvider)
+			assert.True(t, isGhCli)
+
+			// 次はEnvTokenProvider
+			_, isEnv := chain.providers[1].(*EnvTokenProvider)
+			assert.True(t, isEnv)
+		})
+	})
+}
+
+// mockTokenProvider is a test double for TokenProvider
+type mockTokenProvider struct {
+	token  string
+	err    error
+	called bool
+}
+
+func (m *mockTokenProvider) GetToken(ctx context.Context) (string, error) {
+	m.called = true
+	return m.token, m.err
+}
+
+// Integration test (実際のコマンドを使う場合)
+func TestGhCliTokenProvider_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// 実際にgh auth tokenコマンドが使える環境でのみ実行
+	if _, err := exec.LookPath("gh"); err != nil {
+		t.Skip("gh command not found")
+	}
+
+	provider := NewGhCliTokenProvider()
+	ctx := context.Background()
+
+	token, err := provider.GetToken(ctx)
+	// エラーが発生するかトークンが取得できるか
+	// （実行環境によってどちらかになる）
+	if err != nil {
+		assert.Contains(t, err.Error(), "failed to get token from gh cli")
+	} else {
+		assert.NotEmpty(t, token)
+	}
+}

--- a/internal/infra/github/types.go
+++ b/internal/infra/github/types.go
@@ -1,0 +1,51 @@
+package github
+
+import "time"
+
+// Issue はGitHub IssueのAPI応答を表す
+type Issue struct {
+	ID        int64      `json:"id"`
+	Number    int        `json:"number"`
+	Title     string     `json:"title"`
+	Body      string     `json:"body"`
+	State     string     `json:"state"`
+	URL       string     `json:"url"`
+	HTMLURL   string     `json:"html_url"`
+	Labels    []Label    `json:"labels"`
+	Assignees []User     `json:"assignees"`
+	User      User       `json:"user"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	ClosedAt  *time.Time `json:"closed_at"`
+}
+
+// Label はGitHub Labelを表す
+type Label struct {
+	ID    int64  `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+// User はGitHub Userを表す
+type User struct {
+	ID      int64  `json:"id"`
+	Login   string `json:"login"`
+	HTMLURL string `json:"html_url"`
+}
+
+// ListIssuesOptions はIssue一覧取得時のオプション
+type ListIssuesOptions struct {
+	State     string   // open, closed, all
+	Labels    []string // ラベルフィルタ
+	Sort      string   // created, updated, comments
+	Direction string   // asc, desc
+	Since     *time.Time
+	Page      int
+	PerPage   int
+}
+
+// ErrorResponse はGitHub APIのエラーレスポンス
+type ErrorResponse struct {
+	Message          string `json:"message"`
+	DocumentationURL string `json:"documentation_url"`
+}

--- a/pkg/logger/interface.go
+++ b/pkg/logger/interface.go
@@ -1,0 +1,59 @@
+package logger
+
+import "log/slog"
+
+// Logger はロギングインターフェース
+type Logger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
+	With(args ...any) Logger
+}
+
+// slogLogger はslog.Loggerをラップする実装
+type slogLogger struct {
+	logger *slog.Logger
+}
+
+// NewLogger は新しいLoggerを作成する
+func NewLogger(l *slog.Logger) Logger {
+	if l == nil {
+		l = GetLogger()
+	}
+	return &slogLogger{logger: l}
+}
+
+func (l *slogLogger) Debug(msg string, args ...any) {
+	l.logger.Debug(msg, args...)
+}
+
+func (l *slogLogger) Info(msg string, args ...any) {
+	l.logger.Info(msg, args...)
+}
+
+func (l *slogLogger) Warn(msg string, args ...any) {
+	l.logger.Warn(msg, args...)
+}
+
+func (l *slogLogger) Error(msg string, args ...any) {
+	l.logger.Error(msg, args...)
+}
+
+func (l *slogLogger) With(args ...any) Logger {
+	return &slogLogger{logger: l.logger.With(args...)}
+}
+
+// nopLogger は何もしないロガー
+type nopLogger struct{}
+
+// NewNopLogger は何もしないロガーを作成する
+func NewNopLogger() Logger {
+	return &nopLogger{}
+}
+
+func (n *nopLogger) Debug(msg string, args ...any) {}
+func (n *nopLogger) Info(msg string, args ...any)  {}
+func (n *nopLogger) Warn(msg string, args ...any)  {}
+func (n *nopLogger) Error(msg string, args ...any) {}
+func (n *nopLogger) With(args ...any) Logger       { return n }


### PR DESCRIPTION
## 実装完了

fixes #12

### 変更内容
- Token Provider インターフェースと3種類の実装（GhCliTokenProvider, EnvTokenProvider, ChainTokenProvider）
- GitHub API Client基本実装（認証付きHTTPリクエスト、エラーハンドリング）
- Issue取得機能（OpenなIssue一覧、ページネーション、フィルタリング）
- リトライ機構（指数バックオフ、レート制限対応）
- モック実装とテストデータ、統合テストの実装

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス（全93テストがパス）

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし

### 実装詳細

#### 1. Token Provider
- `TokenProvider`インターフェースを定義
- 3種類の実装：
  - `GhCliTokenProvider`: `gh auth token`コマンドからトークンを取得
  - `EnvTokenProvider`: 環境変数からトークンを取得
  - `ChainTokenProvider`: 複数のプロバイダーを順番に試行

#### 2. GitHub API Client
- 認証付きのHTTPリクエスト処理
- エラーレスポンスの解析（レート制限エラーの特別処理含む）
- 構成可能なベースURL（GitHub Enterprise対応）

#### 3. Issue取得機能
- `ListOpenIssues`メソッドでIssue一覧を取得
- ページネーション対応（Linkヘッダーの解析）
- フィルタリングオプション（state, labels, sort, direction等）

#### 4. リトライ機構
- 指数バックオフアルゴリズムの実装
- レート制限ヘッダー（X-RateLimit-Reset）の解析
- 5xx系エラーとネットワークエラーでのリトライ
- クライアントエラー（4xx）ではリトライしない

#### 5. テスト
- 全モジュールに対する単体テスト
- 統合テスト（モックサーバーを使用）
- テスト用フィクスチャとモッククライアント