### PR TITLE
docs: import順のドキュメントをgoimports準拠に変更 (#14)

### DIFF
--- a/docs/development/coding-rules.md
+++ b/docs/development/coding-rules.md
@@ -107,21 +107,36 @@ wg.Wait()
 ## ファイル構造
 
 ### インポート順序
+
+`goimports`のデフォルト動作に準拠し、以下の順序でインポートを記述します：
+
+1. 標準ライブラリ
+2. 外部ライブラリ（空行で区切る）
+3. ローカルパッケージ（空行で区切る）
+
 ```go
 import (
     // 標準ライブラリ
     "context"
     "fmt"
+    "log/slog"
 
     // 外部ライブラリ
     "github.com/google/go-github/v64/github"
     "github.com/spf13/cobra"
+    "github.com/spf13/viper"
 
-    // 内部パッケージ
+    // ローカルパッケージ（github.com/douhashi/soba）
     "github.com/douhashi/soba/internal/config"
     "github.com/douhashi/soba/internal/service"
+    "github.com/douhashi/soba/pkg/logger"
 )
 ```
+
+**注意事項：**
+- `.golangci.yml`で`local-prefixes: github.com/douhashi/soba`が設定されているため、このプレフィックスを持つパッケージは自動的にローカルパッケージとして扱われます
+- 各グループ内ではアルファベット順にソートされます
+- `goimports`を実行することで自動的に適切な順序に整形されます
 
 ## テスト
 


### PR DESCRIPTION
## 実装完了

fixes #14

### 変更内容
- コーディング規約のimport順序を`goimports`準拠に変更
- 標準ライブラリ → 外部ライブラリ → ローカルパッケージの順序を明記
- `.golangci.yml`の`local-prefixes`設定との整合性を明確化

### テスト結果
- ドキュメント変更のみのため自動テスト不要

### 確認事項
- [x] 実装計画に沿った実装
- [x] `goimports`の動作と一致する説明に変更
- [x] `.golangci.yml`の設定（`local-prefixes: github.com/douhashi/soba`）を反映
- [x] 既存機能への影響なし