### PR TITLE
docs: loggerとerror handlingの利用ガイドをコーディング規約に追加 (#16)

### DIFF
--- a/docs/development/coding-rules.md
+++ b/docs/development/coding-rules.md
@@ -59,20 +59,24 @@ type IssueService interface {
 ```
 
 ### エラーハンドリング
-```go
-// カスタムエラー型
-type ValidationError struct {
-    Field string
-    Value interface{}
-}
 
-func (e *ValidationError) Error() string {
-    return fmt.Sprintf("validation failed for %s: %v", e.Field, e.Value)
-}
+**共通エラーハンドラの利用**
+- `pkg/errors`パッケージを使用
+- エラーラップと文脈情報の追加
+- 詳細: [エラーハンドリングガイドライン](./error-handling.md)
+
+```go
+// pkg/errorsを使用したエラーハンドリング
+import "github.com/douhashi/soba/pkg/errors"
 
 // エラーラップ
 if err != nil {
-    return fmt.Errorf("failed to process issue #%d: %w", issueNumber, err)
+    return errors.Wrap(err, "failed to process issue")
+}
+
+// HTTPエラーレスポンス
+func handleError(w http.ResponseWriter, err error) {
+    errors.HandleHTTPError(w, err)
 }
 ```
 
@@ -165,13 +169,28 @@ func TestValidateConfig(t *testing.T) {
 
 ## ログ
 
-### 構造化ログ
+### 共通Loggerの利用
+
+**pkg/loggerパッケージの使用**
+- 統一されたログフォーマット
+- 構造化ログの活用
+- 詳細: [Logger使用ガイド](./logger-usage.md)
+
 ```go
-slog.Info("processing issue",
+import "github.com/douhashi/soba/pkg/logger"
+
+// ロガーの初期化（main関数で一度だけ）
+log := logger.New()
+
+// 構造化ログ
+log.Info("processing issue",
     "issue_number", issue.Number,
     "phase", phase,
     "duration", time.Since(start),
 )
+
+// エラーログ
+log.Error("failed to process", "error", err)
 ```
 
 ## コメント


### PR DESCRIPTION
## 実装完了

fixes #16

### 変更内容
- コーディング規約（`docs/development/coding-rules.md`）にloggerとエラーハンドリングの利用ガイドを追加
- `pkg/logger`パッケージの基本的な使用方法を記載
- `pkg/errors`パッケージの基本的な使用方法を記載
- 詳細ドキュメントへのリンクを設置（`logger-usage.md`、`error-handling.md`）

### テスト結果
- ドキュメント更新のためテストコード不要（Issue要件に記載）
- Markdownリンクの有効性確認: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] 簡潔で簡単な概略の記載
- [x] 詳細ドキュメントへのリンク追加
- [x] 既存のコーディング規約構成を維持