### PR TITLE
feat: Issue監視機能の実装 (#27)

### DIFF
--- a/internal/service/issue_watcher.go
+++ b/internal/service/issue_watcher.go
@@ -1,0 +1,257 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/douhashi/soba/internal/config"
+	"github.com/douhashi/soba/internal/infra/github"
+	"github.com/douhashi/soba/pkg/logger"
+)
+
+// IssueChangeType はIssue変更の種類を表す
+type IssueChangeType string
+
+const (
+	IssueChangeTypeNew          IssueChangeType = "new"
+	IssueChangeTypeLabelChanged IssueChangeType = "label_changed"
+	IssueChangeTypeStateChanged IssueChangeType = "state_changed"
+)
+
+// IssueChange はIssueの変更を表す
+type IssueChange struct {
+	Type     IssueChangeType
+	Issue    github.Issue
+	Previous *github.Issue
+}
+
+// IssueWatcher はIssue監視機能を提供する
+type IssueWatcher struct {
+	client         GitHubClientInterface
+	config         *config.Config
+	interval       time.Duration
+	logger         logger.Logger
+	previousIssues map[int64]github.Issue // Issue IDをキーとする前回の状態
+}
+
+// NewIssueWatcher は新しいIssueWatcherを作成する
+func NewIssueWatcher(client GitHubClientInterface, cfg *config.Config) *IssueWatcher {
+	// デフォルト値の設定
+	if cfg.Workflow.Interval == 0 {
+		cfg.Workflow.Interval = 20
+	}
+
+	// ロガーの初期化（テスト環境を考慮）
+	log := logger.NewNopLogger() // デフォルトでNopLogger使用
+
+	return &IssueWatcher{
+		client:         client,
+		config:         cfg,
+		interval:       time.Duration(cfg.Workflow.Interval) * time.Second,
+		logger:         log,
+		previousIssues: make(map[int64]github.Issue),
+	}
+}
+
+// SetLogger はロガーを設定する（運用時用）
+func (w *IssueWatcher) SetLogger(log logger.Logger) {
+	w.logger = log
+}
+
+// Start はIssue監視を開始する
+func (w *IssueWatcher) Start(ctx context.Context) error {
+	w.logger.Info("Starting Issue watcher", "interval", w.interval)
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	// 最初に一度実行
+	if err := w.watchOnce(ctx); err != nil {
+		w.logger.Error("Initial watch failed", "error", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("Issue watcher stopped due to context cancellation")
+			return nil
+		case <-ticker.C:
+			if err := w.watchOnce(ctx); err != nil {
+				w.logger.Error("Watch cycle failed", "error", err)
+			}
+		}
+	}
+}
+
+// watchOnce は一度だけIssue監視を実行する
+func (w *IssueWatcher) watchOnce(ctx context.Context) error {
+	w.logger.Debug("Starting watch cycle")
+
+	issues, err := w.fetchFilteredIssues(ctx)
+	if err != nil {
+		return err
+	}
+
+	changes := w.detectChanges(issues)
+	if len(changes) > 0 {
+		w.logger.Info("Detected issue changes", "count", len(changes))
+		for _, change := range changes {
+			w.logChange(change)
+		}
+	}
+
+	return nil
+}
+
+// fetchFilteredIssues はフィルタされたIssue一覧を取得する
+func (w *IssueWatcher) fetchFilteredIssues(ctx context.Context) ([]github.Issue, error) {
+	owner, repo := w.parseRepository()
+	if owner == "" || repo == "" {
+		return nil, fmt.Errorf("invalid repository configuration: %s", w.config.GitHub.Repository)
+	}
+
+	opts := &github.ListIssuesOptions{
+		State:   "open",
+		Page:    1,
+		PerPage: 100,
+	}
+
+	issues, _, err := w.client.ListOpenIssues(ctx, owner, repo, opts)
+	if err != nil {
+		w.logger.Error("Failed to fetch issues from GitHub", "error", err, "owner", owner, "repo", repo)
+		return nil, err
+	}
+
+	w.logger.Debug("Fetched issues from GitHub", "total_count", len(issues), "owner", owner, "repo", repo)
+
+	// soba:で始まるラベルを持つIssueのみをフィルタ
+	var filteredIssues []github.Issue
+	for _, issue := range issues {
+		if w.hasSobaLabel(issue) {
+			filteredIssues = append(filteredIssues, issue)
+		}
+	}
+
+	w.logger.Debug("Filtered soba issues", "filtered_count", len(filteredIssues), "total_count", len(issues))
+
+	return filteredIssues, nil
+}
+
+// hasSobaLabel はIssueがsoba:で始まるラベルを持つかチェックする
+func (w *IssueWatcher) hasSobaLabel(issue github.Issue) bool {
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(label.Name, "soba:") {
+			return true
+		}
+	}
+	return false
+}
+
+// detectChanges はIssueの変更を検知する
+func (w *IssueWatcher) detectChanges(currentIssues []github.Issue) []IssueChange {
+	var changes []IssueChange
+
+	// 現在のIssueをマップに変換
+	currentIssueMap := make(map[int64]github.Issue)
+	for _, issue := range currentIssues {
+		currentIssueMap[issue.ID] = issue
+	}
+
+	// 新しいIssueと変更されたIssueをチェック
+	for _, current := range currentIssues {
+		if previous, exists := w.previousIssues[current.ID]; exists {
+			// 既存のIssue - 変更をチェック
+			if w.hasLabelChanged(previous, current) {
+				changes = append(changes, IssueChange{
+					Type:     IssueChangeTypeLabelChanged,
+					Issue:    current,
+					Previous: &previous,
+				})
+			}
+			if previous.State != current.State {
+				changes = append(changes, IssueChange{
+					Type:     IssueChangeTypeStateChanged,
+					Issue:    current,
+					Previous: &previous,
+				})
+			}
+		} else {
+			// 新しいIssue
+			changes = append(changes, IssueChange{
+				Type:  IssueChangeTypeNew,
+				Issue: current,
+			})
+		}
+	}
+
+	// 前回の状態を更新
+	w.previousIssues = currentIssueMap
+
+	return changes
+}
+
+// hasLabelChanged はラベルが変更されたかチェックする
+func (w *IssueWatcher) hasLabelChanged(previous, current github.Issue) bool {
+	if len(previous.Labels) != len(current.Labels) {
+		return true
+	}
+
+	// ラベル名のセットを比較
+	prevLabelNames := make(map[string]bool)
+	for _, label := range previous.Labels {
+		prevLabelNames[label.Name] = true
+	}
+
+	for _, label := range current.Labels {
+		if !prevLabelNames[label.Name] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseRepository は設定からowner/repoを分解する
+func (w *IssueWatcher) parseRepository() (string, string) {
+	repo := w.config.GitHub.Repository
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 {
+		w.logger.Error("Invalid repository format", "repository", repo, "expected_format", "owner/repo")
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
+// logChange は変更をログ出力する
+func (w *IssueWatcher) logChange(change IssueChange) {
+	switch change.Type {
+	case IssueChangeTypeNew:
+		w.logger.Info("New issue detected",
+			"issue_number", change.Issue.Number,
+			"title", change.Issue.Title,
+			"labels", w.formatLabels(change.Issue.Labels))
+	case IssueChangeTypeLabelChanged:
+		w.logger.Info("Issue label changed",
+			"issue_number", change.Issue.Number,
+			"title", change.Issue.Title,
+			"old_labels", w.formatLabels(change.Previous.Labels),
+			"new_labels", w.formatLabels(change.Issue.Labels))
+	case IssueChangeTypeStateChanged:
+		w.logger.Info("Issue state changed",
+			"issue_number", change.Issue.Number,
+			"title", change.Issue.Title,
+			"old_state", change.Previous.State,
+			"new_state", change.Issue.State)
+	}
+}
+
+// formatLabels はラベル一覧を文字列にフォーマットする
+func (w *IssueWatcher) formatLabels(labels []github.Label) string {
+	labelNames := make([]string, 0, len(labels)) // prealloc対応
+	for _, label := range labels {
+		labelNames = append(labelNames, label.Name)
+	}
+	return strings.Join(labelNames, ", ")
+}

--- a/internal/service/issue_watcher_test.go
+++ b/internal/service/issue_watcher_test.go
@@ -1,0 +1,198 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/douhashi/soba/internal/config"
+	"github.com/douhashi/soba/internal/infra/github"
+)
+
+func TestNewIssueWatcher(t *testing.T) {
+	client := &MockGitHubClient{}
+	cfg := &config.Config{
+		Workflow: config.WorkflowConfig{
+			Interval: 20,
+		},
+	}
+
+	watcher := NewIssueWatcher(client, cfg)
+
+	if watcher == nil {
+		t.Error("expected IssueWatcher to be created, got nil")
+	}
+}
+
+func TestIssueWatcher_Watch_WithLabelFilter(t *testing.T) {
+	// テスト用のIssueデータ
+	mockIssues := []github.Issue{
+		{
+			ID:     1,
+			Number: 1,
+			Title:  "Test Issue 1",
+			State:  "open",
+			Labels: []github.Label{
+				{Name: "soba:planning"},
+			},
+		},
+		{
+			ID:     2,
+			Number: 2,
+			Title:  "Test Issue 2",
+			State:  "open",
+			Labels: []github.Label{
+				{Name: "bug"},
+			},
+		},
+	}
+
+	client := &MockGitHubClient{
+		listIssuesFunc: func(ctx context.Context, owner, repo string, options *github.ListIssuesOptions) ([]github.Issue, bool, error) {
+			return mockIssues, false, nil
+		},
+	}
+
+	cfg := &config.Config{
+		GitHub: config.GitHubConfig{
+			Repository: "owner/repo",
+		},
+		Workflow: config.WorkflowConfig{
+			Interval: 20,
+		},
+	}
+
+	watcher := NewIssueWatcher(client, cfg)
+
+	// ラベルフィルタを設定（soba:で始まるラベル）
+	filteredIssues, err := watcher.fetchFilteredIssues(context.Background())
+
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+
+	// soba:planningラベルを持つIssueのみがフィルタされるべき
+	if len(filteredIssues) != 1 {
+		t.Errorf("expected 1 filtered issue, got: %d", len(filteredIssues))
+	}
+
+	if filteredIssues[0].Number != 1 {
+		t.Errorf("expected issue number 1, got: %d", filteredIssues[0].Number)
+	}
+}
+
+func TestIssueWatcher_DetectChanges(t *testing.T) {
+	client := &MockGitHubClient{}
+	cfg := &config.Config{
+		Workflow: config.WorkflowConfig{
+			Interval: 20,
+		},
+	}
+
+	watcher := NewIssueWatcher(client, cfg)
+
+	// 初期状態
+	issue1 := github.Issue{
+		ID:     1,
+		Number: 1,
+		Title:  "Test Issue",
+		State:  "open",
+		Labels: []github.Label{
+			{Name: "soba:planning"},
+		},
+	}
+
+	// 初回設定
+	changes := watcher.detectChanges([]github.Issue{issue1})
+	if len(changes) != 1 {
+		t.Errorf("expected 1 new issue, got: %d", len(changes))
+	}
+	if changes[0].Type != IssueChangeTypeNew {
+		t.Errorf("expected change type 'new', got: %s", changes[0].Type)
+	}
+
+	// ラベル変更
+	issue1Updated := issue1
+	issue1Updated.Labels = []github.Label{
+		{Name: "soba:doing"},
+	}
+
+	changes = watcher.detectChanges([]github.Issue{issue1Updated})
+	if len(changes) != 1 {
+		t.Errorf("expected 1 label change, got: %d", len(changes))
+	}
+	if changes[0].Type != IssueChangeTypeLabelChanged {
+		t.Errorf("expected change type 'label_changed', got: %s", changes[0].Type)
+	}
+}
+
+func TestIssueWatcher_Start_StopOnContext(t *testing.T) {
+	client := &MockGitHubClient{}
+	cfg := &config.Config{
+		GitHub: config.GitHubConfig{
+			Repository: "owner/repo",
+		},
+		Workflow: config.WorkflowConfig{
+			Interval: 1, // 短いインターバルでテスト
+		},
+	}
+
+	watcher := NewIssueWatcher(client, cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Start should return when context is canceled
+	err := watcher.Start(ctx)
+	if err != nil {
+		t.Errorf("expected no error on context cancellation, got: %v", err)
+	}
+}
+
+func TestIssueWatcher_ParseRepositoryFromConfig(t *testing.T) {
+	client := &MockGitHubClient{}
+	cfg := &config.Config{
+		GitHub: config.GitHubConfig{
+			Repository: "owner/repo",
+		},
+		Workflow: config.WorkflowConfig{
+			Interval: 20,
+		},
+	}
+
+	watcher := NewIssueWatcher(client, cfg)
+
+	owner, repo := watcher.parseRepository()
+
+	if owner != "owner" {
+		t.Errorf("expected owner 'owner', got: %s", owner)
+	}
+	if repo != "repo" {
+		t.Errorf("expected repo 'repo', got: %s", repo)
+	}
+}
+
+func TestIssueWatcher_ErrorHandling(t *testing.T) {
+	client := &MockGitHubClient{
+		listIssuesFunc: func(ctx context.Context, owner, repo string, options *github.ListIssuesOptions) ([]github.Issue, bool, error) {
+			return nil, false, fmt.Errorf("API error")
+		},
+	}
+	cfg := &config.Config{
+		GitHub: config.GitHubConfig{
+			Repository: "owner/repo",
+		},
+		Workflow: config.WorkflowConfig{
+			Interval: 20,
+		},
+	}
+
+	watcher := NewIssueWatcher(client, cfg)
+
+	_, err := watcher.fetchFilteredIssues(context.Background())
+
+	if err == nil {
+		t.Error("expected error from GitHub API, got nil")
+	}
+}


### PR DESCRIPTION
## 実装完了

fixes #27

### 変更内容
- Issue監視機能（IssueWatcher）の実装
- 定期ポーリングによるGitHub Issue監視機能
- soba:で始まるラベルのフィルタリング機能
- Issue状態変更検知機能（新規、ラベル変更、状態変更）
- 適切なエラーハンドリングとログ出力
- 包括的なテストケースの実装

### 実装詳細
- **主ファイル**: `internal/service/issue_watcher.go`
  - `IssueWatcher`構造体による監視機能
  - 設定可能なポーリング間隔（デフォルト20秒）
  - soba:プレフィックスラベルによるフィルタリング
  - Issue変更検知とログ出力
  - Context対応による適切な停止処理

- **テストファイル**: `internal/service/issue_watcher_test.go`
  - 5つのテストケースによる機能検証
  - モックを使用した単体テスト
  - エラーハンドリングのテスト
  - タイムアウト処理のテスト

### TDD実践
- Red: テストケース作成と実行（失敗確認）
- Green: 実装によるテスト成功
- Refactor: コード品質向上とエラーハンドリング改善

### テスト結果
- 単体テスト: ✅ パス（IssueWatcher関連全5テスト）
- 全体テスト: ✅ パス（既存機能への影響なし）
- リンター: ✅ パス（golangci-lint, gofmt, prealloc対応）

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] エラーハンドリング実装
- [x] ログ出力の適切な実装
- [x] コーディング規約準拠

### 今後の統合について
このPRではIssueWatcher機能の基本実装を提供します。
DaemonServiceとの統合は別のPRで実装予定です。