### PR TITLE
feat: Workflow Executorの実装 (#29)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spf13/viper v1.19.0 h1:RWq5SEjt8o25SROyN3z2OrDB9l7RPd3lwTWU8EcEdcI=
 github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+Ntkg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/internal/service/daemon.go
+++ b/internal/service/daemon.go
@@ -24,6 +24,7 @@ type DaemonService interface {
 // IssueProcessorInterface はIssue処理のインターフェース
 type IssueProcessorInterface interface {
 	Process(ctx context.Context, cfg *config.Config) error
+	UpdateLabels(ctx context.Context, issueNumber int, removeLabel, addLabel string) error
 }
 
 type daemonService struct {

--- a/internal/service/daemon_test.go
+++ b/internal/service/daemon_test.go
@@ -97,14 +97,22 @@ func TestDaemonService_IsRunning(t *testing.T) {
 
 // MockIssueProcessor はテスト用のモックプロセッサ
 type MockIssueProcessor struct {
-	processFunc   func(ctx context.Context, cfg *config.Config) error
-	processCalled bool
+	processFunc      func(ctx context.Context, cfg *config.Config) error
+	processCalled    bool
+	updateLabelsFunc func(ctx context.Context, issueNumber int, removeLabel, addLabel string) error
 }
 
 func (m *MockIssueProcessor) Process(ctx context.Context, cfg *config.Config) error {
 	m.processCalled = true
 	if m.processFunc != nil {
 		return m.processFunc(ctx, cfg)
+	}
+	return nil
+}
+
+func (m *MockIssueProcessor) UpdateLabels(ctx context.Context, issueNumber int, removeLabel, addLabel string) error {
+	if m.updateLabelsFunc != nil {
+		return m.updateLabelsFunc(ctx, issueNumber, removeLabel, addLabel)
 	}
 	return nil
 }

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -36,3 +36,22 @@ func NewDaemonError(component, reason string) error {
 func WrapServiceError(err error, message string) error {
 	return errors.WrapInternal(err, message)
 }
+
+// NewTmuxManagementError はtmux管理エラーを作成
+func NewTmuxManagementError(operation, target, reason string) error {
+	msg := fmt.Sprintf("tmux %s failed for %s: %s", operation, target, reason)
+	var err error = errors.NewInternalError(msg)
+	err = errors.WithContext(err, "operation", operation)
+	err = errors.WithContext(err, "target", target)
+	return err
+}
+
+// NewCommandExecutionError はコマンド実行エラーを作成
+func NewCommandExecutionError(command, phase string, issueNum int, reason string) error {
+	msg := fmt.Sprintf("command execution failed for phase '%s' on issue #%d: %s", phase, issueNum, reason)
+	var err error = errors.NewInternalError(msg)
+	err = errors.WithContext(err, "command", command)
+	err = errors.WithContext(err, "phase", phase)
+	err = errors.WithContext(err, "issue_number", issueNum)
+	return err
+}

--- a/internal/service/git_workspace.go
+++ b/internal/service/git_workspace.go
@@ -1,0 +1,11 @@
+package service
+
+// GitWorkspaceManager はGitワークスペース管理のインターフェース
+// Issue毎のworktree作成やブランチ管理を行う（実装は後続Issue）
+type GitWorkspaceManager interface {
+	// PrepareWorkspace は指定されたissue番号に対応するワークスペースを準備する
+	PrepareWorkspace(issueNumber int) error
+
+	// CleanupWorkspace は指定されたissue番号に対応するワークスペースをクリーンアップする
+	CleanupWorkspace(issueNumber int) error
+}

--- a/internal/service/issue_processor_test.go
+++ b/internal/service/issue_processor_test.go
@@ -31,6 +31,8 @@ func TestIssueProcessor_Process_EmptyRepository(t *testing.T) {
 type MockGitHubClient struct {
 	listIssuesFunc   func(ctx context.Context, owner, repo string, options *github.ListIssuesOptions) ([]github.Issue, bool, error)
 	listIssuesCalled bool
+	addLabelFunc     func(ctx context.Context, owner, repo string, issueNumber int, label string) error
+	removeLabelFunc  func(ctx context.Context, owner, repo string, issueNumber int, label string) error
 }
 
 func (m *MockGitHubClient) ListOpenIssues(ctx context.Context, owner, repo string, options *github.ListIssuesOptions) ([]github.Issue, bool, error) {
@@ -39,4 +41,18 @@ func (m *MockGitHubClient) ListOpenIssues(ctx context.Context, owner, repo strin
 		return m.listIssuesFunc(ctx, owner, repo, options)
 	}
 	return []github.Issue{}, false, nil
+}
+
+func (m *MockGitHubClient) AddLabelToIssue(ctx context.Context, owner, repo string, issueNumber int, label string) error {
+	if m.addLabelFunc != nil {
+		return m.addLabelFunc(ctx, owner, repo, issueNumber, label)
+	}
+	return nil
+}
+
+func (m *MockGitHubClient) RemoveLabelFromIssue(ctx context.Context, owner, repo string, issueNumber int, label string) error {
+	if m.removeLabelFunc != nil {
+		return m.removeLabelFunc(ctx, owner, repo, issueNumber, label)
+	}
+	return nil
 }

--- a/internal/service/mock_git_workspace.go
+++ b/internal/service/mock_git_workspace.go
@@ -1,0 +1,20 @@
+package service
+
+// MockGitWorkspaceManager はGitWorkspaceManagerのモック実装
+// 実際のワークスペース管理は行わず、テスト用の動作のみを提供する
+type MockGitWorkspaceManager struct{}
+
+// NewMockGitWorkspaceManager は新しいMockGitWorkspaceManagerを作成する
+func NewMockGitWorkspaceManager() GitWorkspaceManager {
+	return &MockGitWorkspaceManager{}
+}
+
+// PrepareWorkspace は成功を返す（モック実装）
+func (m *MockGitWorkspaceManager) PrepareWorkspace(issueNumber int) error {
+	return nil
+}
+
+// CleanupWorkspace は成功を返す（モック実装）
+func (m *MockGitWorkspaceManager) CleanupWorkspace(issueNumber int) error {
+	return nil
+}

--- a/internal/service/workflow_executor.go
+++ b/internal/service/workflow_executor.go
@@ -1,0 +1,195 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/douhashi/soba/internal/config"
+	"github.com/douhashi/soba/internal/domain"
+	"github.com/douhashi/soba/internal/infra/tmux"
+	"github.com/douhashi/soba/pkg/logger"
+)
+
+const (
+	DefaultMaxPanes    = 3
+	DefaultSessionName = "soba"
+)
+
+// WorkflowExecutor はワークフロー実行のインターフェース
+type WorkflowExecutor interface {
+	// ExecutePhase は指定されたフェーズを実行する
+	ExecutePhase(ctx context.Context, cfg *config.Config, issueNumber int, phase domain.Phase, strategy domain.PhaseStrategy) error
+}
+
+// workflowExecutor はWorkflowExecutorの実装
+type workflowExecutor struct {
+	tmux           tmux.TmuxClient
+	workspace      GitWorkspaceManager
+	issueProcessor IssueProcessorUpdater
+	maxPanes       int
+}
+
+// IssueProcessorUpdater はラベル更新機能を持つインターフェース
+type IssueProcessorUpdater interface {
+	UpdateLabels(ctx context.Context, issueNumber int, removeLabel, addLabel string) error
+}
+
+// NewWorkflowExecutor は新しいWorkflowExecutorを作成する
+func NewWorkflowExecutor(tmuxClient tmux.TmuxClient, workspace GitWorkspaceManager, processor IssueProcessorUpdater) WorkflowExecutor {
+	return &workflowExecutor{
+		tmux:           tmuxClient,
+		workspace:      workspace,
+		issueProcessor: processor,
+		maxPanes:       DefaultMaxPanes,
+	}
+}
+
+// ExecutePhase は指定されたフェーズを実行する
+func (e *workflowExecutor) ExecutePhase(ctx context.Context, cfg *config.Config, issueNumber int, phase domain.Phase, strategy domain.PhaseStrategy) error {
+	log := logger.NewNopLogger()
+	log.Info("Executing phase", "issue", issueNumber, "phase", phase)
+
+	// フェーズ遷移情報を取得
+	transition := domain.GetTransition(phase)
+	if transition == nil {
+		return NewWorkflowExecutionError("soba", string(phase), "no transition defined")
+	}
+
+	// ラベルを更新
+	if err := e.issueProcessor.UpdateLabels(ctx, issueNumber, transition.From, transition.To); err != nil {
+		log.Error("Failed to update labels", "error", err, "issue", issueNumber, "from", transition.From, "to", transition.To)
+		return WrapServiceError(err, "failed to update labels")
+	}
+
+	log.Debug("Updated labels", "issue", issueNumber, "from", transition.From, "to", transition.To)
+
+	// tmuxセッション管理
+	sessionName := DefaultSessionName
+	windowName := fmt.Sprintf("issue-%d", issueNumber)
+
+	// セッションが存在しなければ作成
+	if !e.tmux.SessionExists(sessionName) {
+		if err := e.tmux.CreateSession(sessionName); err != nil {
+			log.Error("Failed to create tmux session", "error", err, "session", sessionName)
+			return NewTmuxManagementError("create session", sessionName, err.Error())
+		}
+		log.Debug("Created tmux session", "session", sessionName)
+	}
+
+	// ウィンドウが存在しなければ作成
+	exists, err := e.tmux.WindowExists(sessionName, windowName)
+	if err != nil {
+		log.Error("Failed to check window existence", "error", err, "session", sessionName, "window", windowName)
+		return NewTmuxManagementError("check window", windowName, err.Error())
+	}
+
+	if !exists {
+		if err := e.tmux.CreateWindow(sessionName, windowName); err != nil {
+			log.Error("Failed to create tmux window", "error", err, "session", sessionName, "window", windowName)
+			return NewTmuxManagementError("create window", windowName, err.Error())
+		}
+		log.Debug("Created tmux window", "session", sessionName, "window", windowName)
+	}
+
+	// ペイン管理
+	if err := e.managePane(sessionName, windowName); err != nil {
+		log.Error("Failed to manage pane", "error", err, "session", sessionName, "window", windowName)
+		return err
+	}
+
+	// コマンド構築と実行
+	command := e.buildCommand(e.getPhaseCommand(cfg, phase), issueNumber)
+	if command != "" {
+		// 最初のペインインデックスを取得
+		paneIndex, err := e.tmux.GetFirstPaneIndex(sessionName, windowName)
+		if err != nil {
+			log.Error("Failed to get first pane index", "error", err, "session", sessionName, "window", windowName)
+			return NewTmuxManagementError("get pane index", windowName, err.Error())
+		}
+
+		// コマンド送信
+		if err := e.tmux.SendCommand(sessionName, windowName, paneIndex, command); err != nil {
+			log.Error("Failed to send command", "error", err, "command", command, "pane", paneIndex)
+			return NewCommandExecutionError(command, string(phase), issueNumber, err.Error())
+		}
+		log.Info("Command sent", "issue", issueNumber, "phase", phase, "command", command)
+	}
+
+	log.Info("Phase execution completed", "issue", issueNumber, "phase", phase)
+	return nil
+}
+
+// managePane はペインを管理する（制限数チェック、古いペイン削除、新規作成、リサイズ）
+func (e *workflowExecutor) managePane(sessionName, windowName string) error {
+	log := logger.NewNopLogger()
+
+	// 現在のペイン数を取得
+	paneCount, err := e.tmux.GetPaneCount(sessionName, windowName)
+	if err != nil {
+		return NewTmuxManagementError("get pane count", windowName, err.Error())
+	}
+
+	log.Debug("Current pane count", "session", sessionName, "window", windowName, "count", paneCount)
+
+	// ペイン数が制限に達している場合、最も古いペインを削除
+	if paneCount >= e.maxPanes {
+		firstPaneIndex, err := e.tmux.GetFirstPaneIndex(sessionName, windowName)
+		if err != nil {
+			return NewTmuxManagementError("get first pane index", windowName, err.Error())
+		}
+
+		if err := e.tmux.DeletePane(sessionName, windowName, firstPaneIndex); err != nil {
+			return NewTmuxManagementError("delete pane", windowName, err.Error())
+		}
+		log.Debug("Deleted oldest pane", "session", sessionName, "window", windowName, "index", firstPaneIndex)
+	}
+
+	// 新しいペインを作成
+	if err := e.tmux.CreatePane(sessionName, windowName); err != nil {
+		return NewTmuxManagementError("create pane", windowName, err.Error())
+	}
+	log.Debug("Created new pane", "session", sessionName, "window", windowName)
+
+	// ペインをリサイズ
+	if err := e.tmux.ResizePanes(sessionName, windowName); err != nil {
+		return NewTmuxManagementError("resize panes", windowName, err.Error())
+	}
+	log.Debug("Resized panes", "session", sessionName, "window", windowName)
+
+	return nil
+}
+
+// buildCommand はフェーズコマンドからコマンド文字列を構築する
+func (e *workflowExecutor) buildCommand(phaseCommand config.PhaseCommand, issueNumber int) string {
+	parts := []string{phaseCommand.Command}
+	parts = append(parts, phaseCommand.Options...)
+
+	// パラメータがある場合は追加
+	if phaseCommand.Parameter != "" {
+		param := phaseCommand.Parameter
+		// {issue_number}プレースホルダーを置換
+		param = strings.ReplaceAll(param, "{issue_number}", strconv.Itoa(issueNumber))
+		parts = append(parts, param)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// getPhaseCommand は設定からフェーズ用のコマンドを取得する
+func (e *workflowExecutor) getPhaseCommand(cfg *config.Config, phase domain.Phase) config.PhaseCommand {
+	switch phase {
+	case domain.PhasePlan:
+		return cfg.Phase.Plan
+	case domain.PhaseImplement:
+		return cfg.Phase.Implement
+	case domain.PhaseReview:
+		return cfg.Phase.Review
+	case domain.PhaseRevise:
+		return cfg.Phase.Revise
+	default:
+		// Queue, Mergeなどのフェーズはコマンドなし
+		return config.PhaseCommand{}
+	}
+}

--- a/internal/service/workflow_executor_test.go
+++ b/internal/service/workflow_executor_test.go
@@ -1,0 +1,368 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/douhashi/soba/internal/config"
+	"github.com/douhashi/soba/internal/domain"
+)
+
+type MockTmuxClient struct {
+	mock.Mock
+}
+
+func (m *MockTmuxClient) CreateSession(sessionName string) error {
+	args := m.Called(sessionName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) DeleteSession(sessionName string) error {
+	args := m.Called(sessionName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) SessionExists(sessionName string) bool {
+	args := m.Called(sessionName)
+	return args.Bool(0)
+}
+
+func (m *MockTmuxClient) CreateWindow(sessionName, windowName string) error {
+	args := m.Called(sessionName, windowName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) DeleteWindow(sessionName, windowName string) error {
+	args := m.Called(sessionName, windowName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) WindowExists(sessionName, windowName string) (bool, error) {
+	args := m.Called(sessionName, windowName)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockTmuxClient) CreatePane(sessionName, windowName string) error {
+	args := m.Called(sessionName, windowName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) DeletePane(sessionName, windowName string, paneIndex int) error {
+	args := m.Called(sessionName, windowName, paneIndex)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) GetPaneCount(sessionName, windowName string) (int, error) {
+	args := m.Called(sessionName, windowName)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockTmuxClient) GetFirstPaneIndex(sessionName, windowName string) (int, error) {
+	args := m.Called(sessionName, windowName)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockTmuxClient) ResizePanes(sessionName, windowName string) error {
+	args := m.Called(sessionName, windowName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) SendCommand(sessionName, windowName string, paneIndex int, command string) error {
+	args := m.Called(sessionName, windowName, paneIndex, command)
+	return args.Error(0)
+}
+
+type MockWorkspaceManager struct {
+	mock.Mock
+}
+
+func (m *MockWorkspaceManager) PrepareWorkspace(issueNumber int) error {
+	args := m.Called(issueNumber)
+	return args.Error(0)
+}
+
+func (m *MockWorkspaceManager) CleanupWorkspace(issueNumber int) error {
+	args := m.Called(issueNumber)
+	return args.Error(0)
+}
+
+type MockIssueProcessorUpdater struct {
+	mock.Mock
+}
+
+func (m *MockIssueProcessorUpdater) UpdateLabels(ctx context.Context, issueNumber int, removeLabel, addLabel string) error {
+	args := m.Called(ctx, issueNumber, removeLabel, addLabel)
+	return args.Error(0)
+}
+
+func TestWorkflowExecutor_ExecutePhase(t *testing.T) {
+	tests := []struct {
+		name         string
+		issueNumber  int
+		phase        domain.Phase
+		currentLabel string
+		nextLabel    string
+		setupMocks   func(*MockTmuxClient, *MockWorkspaceManager, *MockIssueProcessorUpdater)
+		wantErr      bool
+		errMessage   string
+	}{
+		{
+			name:         "Execute queue phase successfully",
+			issueNumber:  123,
+			phase:        domain.PhaseQueue,
+			currentLabel: domain.LabelTodo,
+			nextLabel:    domain.LabelQueued,
+			setupMocks: func(tmux *MockTmuxClient, workspace *MockWorkspaceManager, processor *MockIssueProcessorUpdater) {
+				processor.On("UpdateLabels", mock.Anything, 123, domain.LabelTodo, domain.LabelQueued).Return(nil)
+				tmux.On("SessionExists", "soba").Return(false)
+				tmux.On("CreateSession", "soba").Return(nil)
+				tmux.On("WindowExists", "soba", "issue-123").Return(false, nil)
+				tmux.On("CreateWindow", "soba", "issue-123").Return(nil)
+				tmux.On("GetPaneCount", "soba", "issue-123").Return(0, nil)
+				tmux.On("CreatePane", "soba", "issue-123").Return(nil)
+				tmux.On("ResizePanes", "soba", "issue-123").Return(nil)
+				// Queueフェーズはコマンドなしなので、GetFirstPaneIndexとSendCommandは呼ばれない
+			},
+			wantErr: false,
+		},
+		{
+			name:         "Execute plan phase with existing session",
+			issueNumber:  456,
+			phase:        domain.PhasePlan,
+			currentLabel: domain.LabelQueued,
+			nextLabel:    domain.LabelReady,
+			setupMocks: func(tmux *MockTmuxClient, workspace *MockWorkspaceManager, processor *MockIssueProcessorUpdater) {
+				processor.On("UpdateLabels", mock.Anything, 456, domain.LabelQueued, domain.LabelReady).Return(nil)
+				tmux.On("SessionExists", "soba").Return(true)
+				tmux.On("WindowExists", "soba", "issue-456").Return(false, nil)
+				tmux.On("CreateWindow", "soba", "issue-456").Return(nil)
+				tmux.On("GetPaneCount", "soba", "issue-456").Return(0, nil)
+				tmux.On("CreatePane", "soba", "issue-456").Return(nil)
+				tmux.On("ResizePanes", "soba", "issue-456").Return(nil)
+				tmux.On("GetFirstPaneIndex", "soba", "issue-456").Return(0, nil)
+				tmux.On("SendCommand", "soba", "issue-456", 0, "echo Planning").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:         "Delete old pane when max panes reached",
+			issueNumber:  789,
+			phase:        domain.PhaseImplement,
+			currentLabel: domain.LabelReady,
+			nextLabel:    domain.LabelReviewRequested,
+			setupMocks: func(tmux *MockTmuxClient, workspace *MockWorkspaceManager, processor *MockIssueProcessorUpdater) {
+				processor.On("UpdateLabels", mock.Anything, 789, domain.LabelReady, domain.LabelReviewRequested).Return(nil)
+				tmux.On("SessionExists", "soba").Return(true)
+				tmux.On("WindowExists", "soba", "issue-789").Return(true, nil)
+				tmux.On("GetPaneCount", "soba", "issue-789").Return(3, nil)               // Max panes reached
+				tmux.On("GetFirstPaneIndex", "soba", "issue-789").Return(0, nil).Times(2) // 削除と送信で2回呼ばれる
+				tmux.On("DeletePane", "soba", "issue-789", 0).Return(nil)
+				tmux.On("CreatePane", "soba", "issue-789").Return(nil)
+				tmux.On("ResizePanes", "soba", "issue-789").Return(nil)
+				tmux.On("SendCommand", "soba", "issue-789", 0, "echo Implementing").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:         "Error when updating labels",
+			issueNumber:  999,
+			phase:        domain.PhaseReview,
+			currentLabel: domain.LabelReviewRequested,
+			nextLabel:    domain.LabelDone,
+			setupMocks: func(tmux *MockTmuxClient, workspace *MockWorkspaceManager, processor *MockIssueProcessorUpdater) {
+				processor.On("UpdateLabels", mock.Anything, 999, domain.LabelReviewRequested, domain.LabelDone).
+					Return(errors.New("failed to update labels"))
+			},
+			wantErr:    true,
+			errMessage: "failed to update labels",
+		},
+		{
+			name:         "Error when creating tmux session",
+			issueNumber:  111,
+			phase:        domain.PhaseQueue,
+			currentLabel: domain.LabelTodo,
+			nextLabel:    domain.LabelQueued,
+			setupMocks: func(tmux *MockTmuxClient, workspace *MockWorkspaceManager, processor *MockIssueProcessorUpdater) {
+				processor.On("UpdateLabels", mock.Anything, 111, domain.LabelTodo, domain.LabelQueued).Return(nil)
+				tmux.On("SessionExists", "soba").Return(false)
+				tmux.On("CreateSession", "soba").Return(errors.New("tmux error"))
+			},
+			wantErr:    true,
+			errMessage: "tmux error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTmux := new(MockTmuxClient)
+			mockWorkspace := new(MockWorkspaceManager)
+			mockProcessor := new(MockIssueProcessorUpdater)
+
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockTmux, mockWorkspace, mockProcessor)
+			}
+
+			executor := NewWorkflowExecutor(mockTmux, mockWorkspace, mockProcessor)
+
+			cfg := &config.Config{
+				Phase: config.PhaseConfig{
+					Plan:      config.PhaseCommand{Command: "echo", Options: []string{}, Parameter: "Planning"},
+					Implement: config.PhaseCommand{Command: "echo", Options: []string{}, Parameter: "Implementing"},
+					Review:    config.PhaseCommand{Command: "echo", Options: []string{}, Parameter: "Review"},
+				},
+			}
+
+			phaseStrategy := domain.NewDefaultPhaseStrategy()
+			ctx := context.Background()
+
+			err := executor.ExecutePhase(ctx, cfg, tt.issueNumber, tt.phase, phaseStrategy)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMessage != "" {
+					assert.Contains(t, err.Error(), tt.errMessage)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockTmux.AssertExpectations(t)
+			mockWorkspace.AssertExpectations(t)
+			mockProcessor.AssertExpectations(t)
+		})
+	}
+}
+
+func TestWorkflowExecutor_managePane(t *testing.T) {
+	tests := []struct {
+		name        string
+		sessionName string
+		windowName  string
+		maxPanes    int
+		setupMocks  func(*MockTmuxClient)
+		wantErr     bool
+		errMessage  string
+	}{
+		{
+			name:        "Create new pane when under limit",
+			sessionName: "soba",
+			windowName:  "issue-123",
+			maxPanes:    3,
+			setupMocks: func(tmux *MockTmuxClient) {
+				tmux.On("GetPaneCount", "soba", "issue-123").Return(2, nil)
+				tmux.On("CreatePane", "soba", "issue-123").Return(nil)
+				tmux.On("ResizePanes", "soba", "issue-123").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "Delete oldest pane when at limit",
+			sessionName: "soba",
+			windowName:  "issue-456",
+			maxPanes:    3,
+			setupMocks: func(tmux *MockTmuxClient) {
+				tmux.On("GetPaneCount", "soba", "issue-456").Return(3, nil)
+				tmux.On("GetFirstPaneIndex", "soba", "issue-456").Return(0, nil)
+				tmux.On("DeletePane", "soba", "issue-456", 0).Return(nil)
+				tmux.On("CreatePane", "soba", "issue-456").Return(nil)
+				tmux.On("ResizePanes", "soba", "issue-456").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "Error getting pane count",
+			sessionName: "soba",
+			windowName:  "issue-789",
+			maxPanes:    3,
+			setupMocks: func(tmux *MockTmuxClient) {
+				tmux.On("GetPaneCount", "soba", "issue-789").Return(0, errors.New("tmux error"))
+			},
+			wantErr:    true,
+			errMessage: "tmux error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTmux := new(MockTmuxClient)
+			mockWorkspace := new(MockWorkspaceManager)
+			mockProcessor := new(MockIssueProcessorUpdater)
+
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockTmux)
+			}
+
+			executor := &workflowExecutor{
+				tmux:           mockTmux,
+				workspace:      mockWorkspace,
+				issueProcessor: mockProcessor,
+				maxPanes:       tt.maxPanes,
+			}
+
+			err := executor.managePane(tt.sessionName, tt.windowName)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMessage != "" {
+					assert.Contains(t, err.Error(), tt.errMessage)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockTmux.AssertExpectations(t)
+		})
+	}
+}
+
+func TestWorkflowExecutor_buildCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		phaseCommand config.PhaseCommand
+		issueNumber  int
+		expected     string
+	}{
+		{
+			name: "Build command with parameter",
+			phaseCommand: config.PhaseCommand{
+				Command:   "soba",
+				Options:   []string{"plan"},
+				Parameter: "123",
+			},
+			issueNumber: 123,
+			expected:    "soba plan 123",
+		},
+		{
+			name: "Build command without parameter",
+			phaseCommand: config.PhaseCommand{
+				Command:   "echo",
+				Options:   []string{"Hello", "World"},
+				Parameter: "",
+			},
+			issueNumber: 456,
+			expected:    "echo Hello World",
+		},
+		{
+			name: "Build command with issue number placeholder",
+			phaseCommand: config.PhaseCommand{
+				Command:   "gh",
+				Options:   []string{"issue", "view"},
+				Parameter: "{issue_number}",
+			},
+			issueNumber: 789,
+			expected:    "gh issue view 789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &workflowExecutor{}
+			result := executor.buildCommand(tt.phaseCommand, tt.issueNumber)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## 実装完了

fixes #29

### 変更内容
- WorkflowExecutorインターフェースと実装
- Phase実行ロジック（ラベル更新、tmux制御、コマンド実行）
- tmux管理機能（セッション/ウィンドウ/ペイン管理）
- ペイン数制限機能（デフォルト3、古いペイン自動削除）
- コマンド実行機能（設定ファイルからPhase別コマンド読込）
- GitWorkspaceManagerインターフェース（モック実装）
- IssueProcessorへのUpdateLabelsメソッド追加と統合
- GitHubクライアントへのラベル操作メソッド追加
- エラーハンドリングとロギング実装

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし