### PR TITLE
feat: IssueProcessorにPhaseStrategyとWorkflowExecutorを統合 (#31)

### DIFF
--- a/internal/service/git_workspace.go
+++ b/internal/service/git_workspace.go
@@ -9,3 +9,27 @@ type GitWorkspaceManager interface {
 	// CleanupWorkspace は指定されたissue番号に対応するワークスペースをクリーンアップする
 	CleanupWorkspace(issueNumber int) error
 }
+
+// gitWorkspaceManager は GitWorkspaceManager の実装
+type gitWorkspaceManager struct {
+	workDir string
+}
+
+// NewGitWorkspaceManager は新しいGitWorkspaceManagerを作成する
+func NewGitWorkspaceManager(workDir string) GitWorkspaceManager {
+	return &gitWorkspaceManager{
+		workDir: workDir,
+	}
+}
+
+// PrepareWorkspace は指定されたissue番号に対応するワークスペースを準備する
+func (g *gitWorkspaceManager) PrepareWorkspace(issueNumber int) error {
+	// TODO: 実装は後続Issueで行う
+	return nil
+}
+
+// CleanupWorkspace は指定されたissue番号に対応するワークスペースをクリーンアップする
+func (g *gitWorkspaceManager) CleanupWorkspace(issueNumber int) error {
+	// TODO: 実装は後続Issueで行う
+	return nil
+}

--- a/internal/service/issue_processor_test.go
+++ b/internal/service/issue_processor_test.go
@@ -2,16 +2,34 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
+	"github.com/douhashi/soba/internal/config"
+	"github.com/douhashi/soba/internal/domain"
 	"github.com/douhashi/soba/internal/infra/github"
 )
 
 func TestNewIssueProcessor(t *testing.T) {
-	processor := NewIssueProcessor()
+	mockGithub := &MockGitHubClient{}
+	mockExecutor := &MockWorkflowExecutor{}
+	mockStrategy := domain.NewDefaultPhaseStrategy()
+
+	processor := NewIssueProcessorWithDependencies(mockGithub, mockExecutor, mockStrategy)
 	assert.NotNil(t, processor)
+}
+
+// MockWorkflowExecutor はWorkflowExecutorのモック
+type MockWorkflowExecutor struct {
+	mock.Mock
+}
+
+func (m *MockWorkflowExecutor) ExecutePhase(ctx context.Context, cfg *config.Config, issueNumber int, phase domain.Phase, strategy domain.PhaseStrategy) error {
+	args := m.Called(ctx, cfg, issueNumber, phase, strategy)
+	return args.Error(0)
 }
 
 // IssueProcessor_Processもloggingシステムとの競合でテストが困難なため、スキップ
@@ -55,4 +73,123 @@ func (m *MockGitHubClient) RemoveLabelFromIssue(ctx context.Context, owner, repo
 		return m.removeLabelFunc(ctx, owner, repo, issueNumber, label)
 	}
 	return nil
+}
+
+func TestIssueProcessor_ProcessIssue(t *testing.T) {
+	tests := []struct {
+		name        string
+		issue       github.Issue
+		expectPhase domain.Phase
+		expectError bool
+		setupMock   func(*MockWorkflowExecutor)
+	}{
+		{
+			name: "Process issue with soba:todo label",
+			issue: github.Issue{
+				Number: 1,
+				Title:  "Test Issue",
+				Labels: []github.Label{
+					{Name: "soba:todo"},
+				},
+			},
+			expectPhase: domain.PhaseQueue,
+			expectError: false,
+			setupMock: func(m *MockWorkflowExecutor) {
+				m.On("ExecutePhase", mock.Anything, mock.Anything, 1, domain.PhaseQueue, mock.Anything).Return(nil)
+			},
+		},
+		{
+			name: "Process issue with soba:queued label",
+			issue: github.Issue{
+				Number: 2,
+				Title:  "Test Issue 2",
+				Labels: []github.Label{
+					{Name: "soba:queued"},
+				},
+			},
+			expectPhase: domain.PhasePlan,
+			expectError: false,
+			setupMock: func(m *MockWorkflowExecutor) {
+				m.On("ExecutePhase", mock.Anything, mock.Anything, 2, domain.PhasePlan, mock.Anything).Return(nil)
+			},
+		},
+		{
+			name: "Process issue with soba:ready label",
+			issue: github.Issue{
+				Number: 3,
+				Title:  "Test Issue 3",
+				Labels: []github.Label{
+					{Name: "soba:ready"},
+				},
+			},
+			expectPhase: domain.PhaseImplement,
+			expectError: false,
+			setupMock: func(m *MockWorkflowExecutor) {
+				m.On("ExecutePhase", mock.Anything, mock.Anything, 3, domain.PhaseImplement, mock.Anything).Return(nil)
+			},
+		},
+		{
+			name: "Process issue with no soba labels",
+			issue: github.Issue{
+				Number: 4,
+				Title:  "Test Issue 4",
+				Labels: []github.Label{
+					{Name: "bug"},
+					{Name: "enhancement"},
+				},
+			},
+			expectPhase: "",
+			expectError: true,
+			setupMock: func(m *MockWorkflowExecutor) {
+			},
+		},
+		{
+			name: "Process issue with workflow execution error",
+			issue: github.Issue{
+				Number: 5,
+				Title:  "Test Issue 5",
+				Labels: []github.Label{
+					{Name: "soba:todo"},
+				},
+			},
+			expectPhase: domain.PhaseQueue,
+			expectError: true,
+			setupMock: func(m *MockWorkflowExecutor) {
+				m.On("ExecutePhase", mock.Anything, mock.Anything, 5, domain.PhaseQueue, mock.Anything).Return(fmt.Errorf("execution failed"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockGithub := &MockGitHubClient{}
+			mockExecutor := &MockWorkflowExecutor{}
+			mockStrategy := domain.NewDefaultPhaseStrategy()
+
+			if tt.setupMock != nil {
+				tt.setupMock(mockExecutor)
+			}
+
+			processor := NewIssueProcessorWithDependencies(mockGithub, mockExecutor, mockStrategy)
+
+			ctx := context.Background()
+			cfg := &config.Config{
+				GitHub: config.GitHubConfig{
+					Repository: "owner/repo",
+				},
+			}
+
+			err := processor.ProcessIssue(ctx, cfg, tt.issue)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if !tt.expectError && tt.setupMock != nil {
+				mockExecutor.AssertExpectations(t)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## 実装完了

fixes #31

### 変更内容

IssueProcessorを拡張し、PhaseStrategyおよびWorkflowExecutorと連携してGitHub Issueのラベル遷移を自動化する機能を実装しました。

#### 主な実装内容:

1. **IssueProcessor構造体の拡張**
   - WorkflowExecutorとPhaseStrategyをフィールドに追加
   - 依存関係の注入パターンを採用

2. **ProcessIssueメソッドの実装**
   - 単一Issue処理ロジックの実装
   - ラベルから現在のフェーズを判定し、適切なフェーズを実行

3. **コンストラクタの修正**
   - NewIssueProcessorWithDependenciesコンストラクタを追加
   - DaemonサービスでのIssueProcessor初期化を更新

4. **IssueWatcherとの統合**
   - SetProcessorメソッドを追加
   - ラベル変更時にProcessIssueを呼び出すよう修正

5. **Daemonサービスとの連携**
   - IssueWatcher方式への移行
   - 依存関係の初期化とワイヤリングを実装

6. **GitWorkspaceManagerのスタブ実装**
   - インターフェースの実装を追加（詳細実装は後続Issue）

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス

#### テスト内容:
- IssueProcessor.ProcessIssue: 各ラベル状態でのフェーズ判定と実行
- エラーハンドリング: ラベル不在時、実行失敗時の処理
- モックを使用した依存関係のテスト

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] TDDアプローチに従った開発

### アーキテクチャ上の考慮点
- 既存のサービスレイヤーアーキテクチャに従った実装
- エラーハンドリングは既存のerrorsパッケージを使用
- ロガーはテスト環境での競合を回避するためNopLoggerを使用