### PR TITLE
fix: GitHubクライアントとリポジトリ情報の初期化エラーを修正

### DIFF
--- a/internal/service/daemon_test.go
+++ b/internal/service/daemon_test.go
@@ -125,3 +125,7 @@ func (m *MockIssueProcessor) ProcessIssue(ctx context.Context, cfg *config.Confi
 	}
 	return nil
 }
+
+func (m *MockIssueProcessor) Configure(cfg *config.Config) error {
+	return nil
+}

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -92,6 +92,8 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 
 	// WorkflowExecutorとIssueProcessorを初期化
 	mockProcessorUpdater := new(MockIssueProcessorUpdater)
+	// Configure呼び出し
+	mockProcessorUpdater.On("Configure", mock.Anything).Return(nil).Once()
 	// Queueフェーズでラベル更新
 	mockProcessorUpdater.On("UpdateLabels", mock.Anything, 1, "soba:todo", "soba:queued").Return(nil).Once()
 
@@ -160,6 +162,7 @@ func TestIntegration_ErrorHandling(t *testing.T) {
 	mockTmux.On("ResizePanes", "soba", "issue-1").Return(nil).Once()
 
 	// ラベル更新のモック
+	mockProcessor.On("Configure", mock.Anything).Return(nil).Once()
 	mockProcessor.On("UpdateLabels", mock.Anything, 1, "soba:todo", "soba:queued").Return(nil).Once()
 
 	cfg := &config.Config{
@@ -173,7 +176,7 @@ func TestIntegration_ErrorHandling(t *testing.T) {
 
 	executor := NewWorkflowExecutor(mockTmux, mockWorkspace, mockProcessor)
 	strategy := domain.NewDefaultPhaseStrategy()
-	processor := NewIssueProcessorWithDependencies(mockGitHub, executor, strategy)
+	processor := NewIssueProcessor(mockGitHub, executor, strategy)
 
 	watcher := NewIssueWatcher(mockGitHub, cfg)
 	watcher.SetPhaseStrategy(strategy)

--- a/internal/service/issue_processor_test.go
+++ b/internal/service/issue_processor_test.go
@@ -18,7 +18,7 @@ func TestNewIssueProcessor(t *testing.T) {
 	mockExecutor := &MockWorkflowExecutor{}
 	mockStrategy := domain.NewDefaultPhaseStrategy()
 
-	processor := NewIssueProcessorWithDependencies(mockGithub, mockExecutor, mockStrategy)
+	processor := NewIssueProcessor(mockGithub, mockExecutor, mockStrategy)
 	assert.NotNil(t, processor)
 }
 
@@ -170,7 +170,7 @@ func TestIssueProcessor_ProcessIssue(t *testing.T) {
 				tt.setupMock(mockExecutor)
 			}
 
-			processor := NewIssueProcessorWithDependencies(mockGithub, mockExecutor, mockStrategy)
+			processor := NewIssueProcessor(mockGithub, mockExecutor, mockStrategy)
 
 			ctx := context.Background()
 			cfg := &config.Config{


### PR DESCRIPTION
## 概要
IssueProcessorでGitHubクライアントとowner/repo情報が正しく初期化されない問題を修正しました。

## 問題
`soba start`実行時に以下のエラーが発生していました：
- "GitHub client not initialized"
- "repository info not set"

## 原因
1. `daemon.go`でWorkflowExecutorに渡すIssueProcessorがGitHubクライアントなしで初期化されていた
2. `UpdateLabels`メソッド呼び出し時にowner/repo情報が未設定だった

## 修正内容
- IssueProcessorInterfaceに`Configure()`メソッドを追加
- WorkflowExecutorの`ExecutePhase`開始時に`Configure()`を呼び出すように修正
- daemon.goの初期化順序を修正し、GitHubクライアント付きでProcessorを初期化
- `ProcessIssue`メソッドでもGitHubクライアントとowner/repo情報を設定
- テストファイルのモックインターフェースに`Configure()`メソッドを追加

## テスト
- 全テストが成功することを確認済み
- pre-commitチェックも通過

## 動作確認
修正後、`soba start`が正常に動作することを確認してください。

🤖 Generated with [Claude Code](https://claude.ai/code)