### PR TITLE
feat: tmuxセッション管理の改善 (#54)

### DIFF
--- a/internal/infra/tmux/client.go
+++ b/internal/infra/tmux/client.go
@@ -350,17 +350,17 @@ func (c *Client) SendCommand(sessionName, windowName string, paneIndex int, comm
 }
 
 // isProtectedSession は指定されたセッションが削除から保護されているかを判定する
-// 開発中のセッション（soba-douhashi-soba）は誤削除を防ぐため保護される
+// sobaプレフィックスのセッションは誤削除を防ぐため保護される（テスト用を除く）
 func isProtectedSession(sessionName string) bool {
-	// 現在の開発セッション（soba-douhashi-soba）を保護
-	protectedSessions := []string{
-		"soba-douhashi-soba",
+	// テストセッションは保護対象外
+	if strings.HasPrefix(sessionName, "soba-test-") {
+		return false
 	}
 
-	for _, protected := range protectedSessions {
-		if sessionName == protected {
-			return true
-		}
+	// sobaで始まるセッションはすべて保護対象
+	// これには旧形式の"soba"と新形式の"soba-owner-repo"が含まれる
+	if strings.HasPrefix(sessionName, "soba") {
+		return true
 	}
 
 	return false

--- a/internal/infra/tmux/client_test.go
+++ b/internal/infra/tmux/client_test.go
@@ -400,18 +400,28 @@ func TestIsProtectedSession(t *testing.T) {
 		want        bool
 	}{
 		{
-			name:        "保護対象セッション",
+			name:        "保護対象セッション（新形式）",
 			sessionName: "soba-douhashi-soba",
 			want:        true,
 		},
 		{
-			name:        "通常のセッション",
-			sessionName: "soba-test-session",
-			want:        false,
+			name:        "保護対象セッション（旧形式）",
+			sessionName: "soba",
+			want:        true,
+		},
+		{
+			name:        "別のsobaセッション",
+			sessionName: "soba-user-repo",
+			want:        true,
 		},
 		{
 			name:        "sobaプレフィックスではない",
 			sessionName: "normal-session",
+			want:        false,
+		},
+		{
+			name:        "テストセッション",
+			sessionName: "test-soba-session",
 			want:        false,
 		},
 	}

--- a/internal/service/workflow_executor.go
+++ b/internal/service/workflow_executor.go
@@ -109,7 +109,7 @@ func (e *workflowExecutor) executeCommandPhase(cfg *config.Config, issueNumber i
 	}
 
 	// tmuxセッション管理
-	sessionName := DefaultSessionName
+	sessionName := e.generateSessionName(cfg.GitHub.Repository)
 	windowName := fmt.Sprintf("issue-%d", issueNumber)
 
 	// tmuxセッションとウィンドウのセットアップ
@@ -305,6 +305,25 @@ func (e *workflowExecutor) buildCommand(phaseCommand config.PhaseCommand, issueN
 	}
 
 	return strings.Join(parts, " ")
+}
+
+// generateSessionName はリポジトリ情報からセッション名を生成する
+func (e *workflowExecutor) generateSessionName(repository string) string {
+	if repository == "" {
+		return DefaultSessionName
+	}
+
+	// スラッシュで分割して所有者とリポジトリ名を結合
+	parts := strings.Split(repository, "/")
+	if len(parts) < 2 {
+		// 不正な形式の場合はデフォルトに戻る
+		return DefaultSessionName
+	}
+
+	// "soba-{owner}-{repo}"形式で生成
+	// 複数のスラッシュがある場合も全て結合
+	sessionName := "soba-" + strings.Join(parts, "-")
+	return sessionName
 }
 
 // getPhaseCommand は設定からフェーズ用のコマンドを取得する

--- a/internal/service/workflow_executor_test.go
+++ b/internal/service/workflow_executor_test.go
@@ -144,12 +144,12 @@ func TestWorkflowExecutor_ExecutePhase(t *testing.T) {
 				processor.On("Configure", mock.Anything).Return(nil)
 				processor.On("UpdateLabels", mock.Anything, 456, domain.LabelQueued, domain.LabelPlanning).Return(nil)
 				workspace.On("PrepareWorkspace", 456).Return(nil) // Planフェーズでworktree準備
-				tmux.On("SessionExists", "soba").Return(true)
-				tmux.On("WindowExists", "soba", "issue-456").Return(false, nil)
-				tmux.On("CreateWindow", "soba", "issue-456").Return(nil)
+				tmux.On("SessionExists", "soba-test-repo").Return(true)
+				tmux.On("WindowExists", "soba-test-repo", "issue-456").Return(false, nil)
+				tmux.On("CreateWindow", "soba-test-repo", "issue-456").Return(nil)
 				// Window was created, so no pane management
-				tmux.On("GetLastPaneIndex", "soba", "issue-456").Return(0, nil)
-				tmux.On("SendCommand", "soba", "issue-456", 0, `cd .git/soba/worktrees/issue-456 && echo "Planning"`).Return(nil)
+				tmux.On("GetLastPaneIndex", "soba-test-repo", "issue-456").Return(0, nil)
+				tmux.On("SendCommand", "soba-test-repo", "issue-456", 0, `cd .git/soba/worktrees/issue-456 && echo "Planning"`).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -163,15 +163,15 @@ func TestWorkflowExecutor_ExecutePhase(t *testing.T) {
 				processor.On("Configure", mock.Anything).Return(nil)
 				processor.On("UpdateLabels", mock.Anything, 789, domain.LabelReady, domain.LabelDoing).Return(nil)
 				workspace.On("PrepareWorkspace", 789).Return(nil) // Implementフェーズでworktree準備
-				tmux.On("SessionExists", "soba").Return(true)
-				tmux.On("WindowExists", "soba", "issue-789").Return(true, nil)
-				tmux.On("GetPaneCount", "soba", "issue-789").Return(3, nil)      // Max panes reached
-				tmux.On("GetFirstPaneIndex", "soba", "issue-789").Return(0, nil) // 削除用
-				tmux.On("DeletePane", "soba", "issue-789", 0).Return(nil)
-				tmux.On("CreatePane", "soba", "issue-789").Return(nil)
-				tmux.On("ResizePanes", "soba", "issue-789").Return(nil)
-				tmux.On("GetLastPaneIndex", "soba", "issue-789").Return(2, nil) // 送信用（新しいペイン）
-				tmux.On("SendCommand", "soba", "issue-789", 2, `cd .git/soba/worktrees/issue-789 && echo "Implementing"`).Return(nil)
+				tmux.On("SessionExists", "soba-test-repo").Return(true)
+				tmux.On("WindowExists", "soba-test-repo", "issue-789").Return(true, nil)
+				tmux.On("GetPaneCount", "soba-test-repo", "issue-789").Return(3, nil)      // Max panes reached
+				tmux.On("GetFirstPaneIndex", "soba-test-repo", "issue-789").Return(0, nil) // 削除用
+				tmux.On("DeletePane", "soba-test-repo", "issue-789", 0).Return(nil)
+				tmux.On("CreatePane", "soba-test-repo", "issue-789").Return(nil)
+				tmux.On("ResizePanes", "soba-test-repo", "issue-789").Return(nil)
+				tmux.On("GetLastPaneIndex", "soba-test-repo", "issue-789").Return(2, nil) // 送信用（新しいペイン）
+				tmux.On("SendCommand", "soba-test-repo", "issue-789", 2, `cd .git/soba/worktrees/issue-789 && echo "Implementing"`).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -199,8 +199,8 @@ func TestWorkflowExecutor_ExecutePhase(t *testing.T) {
 				processor.On("Configure", mock.Anything).Return(nil)
 				processor.On("UpdateLabels", mock.Anything, 111, domain.LabelQueued, domain.LabelPlanning).Return(nil)
 				workspace.On("PrepareWorkspace", 111).Return(nil) // Planフェーズでworktree準備
-				tmux.On("SessionExists", "soba").Return(false)
-				tmux.On("CreateSession", "soba").Return(errors.New("tmux error"))
+				tmux.On("SessionExists", "soba-test-repo").Return(false)
+				tmux.On("CreateSession", "soba-test-repo").Return(errors.New("tmux error"))
 			},
 			wantErr:    true,
 			errMessage: "tmux error",
@@ -222,6 +222,9 @@ func TestWorkflowExecutor_ExecutePhase(t *testing.T) {
 			cfg := &config.Config{
 				Git: config.GitConfig{
 					WorktreeBasePath: ".git/soba/worktrees",
+				},
+				GitHub: config.GitHubConfig{
+					Repository: "test/repo",
 				},
 				Phase: config.PhaseConfig{
 					Plan:      config.PhaseCommand{Command: "echo", Options: []string{}, Parameter: "Planning"},
@@ -343,18 +346,21 @@ func TestWorkflowExecutor_ExecutePhase_WithWorktreePreparation(t *testing.T) {
 	mockProcessor.On("Configure", mock.Anything).Return(nil) // Configure呼び出しを追加
 	mockProcessor.On("UpdateLabels", mock.Anything, 1, "soba:queued", "soba:planning").Return(nil)
 	mockWorkspace.On("PrepareWorkspace", 1).Return(nil) // worktree準備が呼ばれることを期待
-	mockTmux.On("SessionExists", "soba").Return(true)
-	mockTmux.On("WindowExists", "soba", "issue-1").Return(false, nil)
-	mockTmux.On("CreateWindow", "soba", "issue-1").Return(nil)
+	mockTmux.On("SessionExists", "soba-test-repo").Return(true)
+	mockTmux.On("WindowExists", "soba-test-repo", "issue-1").Return(false, nil)
+	mockTmux.On("CreateWindow", "soba-test-repo", "issue-1").Return(nil)
 	// Window was created, so no pane management
-	mockTmux.On("GetLastPaneIndex", "soba", "issue-1").Return(0, nil)
-	mockTmux.On("SendCommand", "soba", "issue-1", 0, `cd .git/soba/worktrees/issue-1 && soba:plan "1"`).Return(nil)
+	mockTmux.On("GetLastPaneIndex", "soba-test-repo", "issue-1").Return(0, nil)
+	mockTmux.On("SendCommand", "soba-test-repo", "issue-1", 0, `cd .git/soba/worktrees/issue-1 && soba:plan "1"`).Return(nil)
 
 	executor := NewWorkflowExecutorWithLogger(mockTmux, mockWorkspace, mockProcessor, logger.NewNopLogger())
 
 	cfg := &config.Config{
 		Git: config.GitConfig{
 			WorktreeBasePath: ".git/soba/worktrees",
+		},
+		GitHub: config.GitHubConfig{
+			Repository: "test/repo",
 		},
 		Phase: config.PhaseConfig{
 			Plan: config.PhaseCommand{
@@ -416,26 +422,29 @@ func TestWorkflowExecutor_executeCommandPhase_PaneSkip(t *testing.T) {
 			mockWorkspace := new(MockWorkspaceManager)
 
 			// Setup tmux session mocks
-			mockTmux.On("SessionExists", "soba").Return(true)
-			mockTmux.On("WindowExists", "soba", "issue-42").Return(tt.windowExists, nil)
+			mockTmux.On("SessionExists", "soba-test-repo").Return(true)
+			mockTmux.On("WindowExists", "soba-test-repo", "issue-42").Return(tt.windowExists, nil)
 
 			if !tt.windowExists {
 				// Window will be created
-				mockTmux.On("CreateWindow", "soba", "issue-42").Return(nil)
+				mockTmux.On("CreateWindow", "soba-test-repo", "issue-42").Return(nil)
 			}
 
 			// Setup pane management mocks if expected
 			if tt.expectManagePane {
-				mockTmux.On("GetPaneCount", "soba", "issue-42").Return(1, nil)
-				mockTmux.On("CreatePane", "soba", "issue-42").Return(nil)
-				mockTmux.On("ResizePanes", "soba", "issue-42").Return(nil)
+				mockTmux.On("GetPaneCount", "soba-test-repo", "issue-42").Return(1, nil)
+				mockTmux.On("CreatePane", "soba-test-repo", "issue-42").Return(nil)
+				mockTmux.On("ResizePanes", "soba-test-repo", "issue-42").Return(nil)
 			}
 
 			// Setup command execution mocks
-			mockTmux.On("GetLastPaneIndex", "soba", "issue-42").Return(0, nil)
-			mockTmux.On("SendCommand", "soba", "issue-42", 0, mock.Anything).Return(nil)
+			mockTmux.On("GetLastPaneIndex", "soba-test-repo", "issue-42").Return(0, nil)
+			mockTmux.On("SendCommand", "soba-test-repo", "issue-42", 0, mock.Anything).Return(nil)
 
 			cfg := &config.Config{
+				GitHub: config.GitHubConfig{
+					Repository: "test/repo",
+				},
 				Workflow: config.WorkflowConfig{
 					TmuxCommandDelay: 0,
 				},
@@ -543,6 +552,48 @@ func TestWorkflowExecutor_buildCommand(t *testing.T) {
 			executor := &workflowExecutor{}
 			result := executor.buildCommand(tt.phaseCommand, tt.issueNumber)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateSessionName(t *testing.T) {
+	tests := []struct {
+		name       string
+		repository string
+		want       string
+	}{
+		{
+			name:       "Normal repository format",
+			repository: "douhashi/soba",
+			want:       "soba-douhashi-soba",
+		},
+		{
+			name:       "Repository with special characters",
+			repository: "user-name/repo.name",
+			want:       "soba-user-name-repo.name",
+		},
+		{
+			name:       "Empty repository",
+			repository: "",
+			want:       "soba",
+		},
+		{
+			name:       "Repository without slash",
+			repository: "invalid",
+			want:       "soba",
+		},
+		{
+			name:       "Repository with multiple slashes",
+			repository: "org/sub/repo",
+			want:       "soba-org-sub-repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &workflowExecutor{}
+			result := executor.generateSessionName(tt.repository)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }


### PR DESCRIPTION
## 実装完了

fixes #54

### 変更内容

#### tmuxセッション管理の改善
- `soba start`実行時点でtmuxセッションを作成するように変更
- セッション名を`soba-{owner}-{repository}`形式に動的生成
- リポジトリ情報に基づいてセッション名を自動決定

### 実装詳細

#### 1. セッション名生成機能
- `workflowExecutor.generateSessionName()`関数を追加
- `daemonService.generateSessionName()`関数を追加（同じロジック）
- 不正な入力に対するフォールバック処理を実装

#### 2. 起動時のセッション初期化
- `daemonService.initializeTmuxSession()`メソッドを追加
- `StartForeground()`と`StartDaemon()`でセッション初期化を実行
- セッションが既に存在する場合はスキップ

#### 3. WorkflowExecutorでの動的セッション名利用
- `executeCommandPhase()`でconfig経由でセッション名を取得
- 固定値`DefaultSessionName`から動的な名前に変更

#### 4. 保護セッション判定の更新
- `isProtectedSession()`関数を`soba`プレフィックスベースに更新
- 旧形式（`soba`）と新形式（`soba-owner-repo`）の両方をサポート

### テスト結果
- 単体テスト: ✅ パス
  - セッション名生成関数のテスト
  - DaemonServiceのセッション初期化テスト
  - WorkflowExecutorのセッション利用テスト
  - 保護セッション判定のテスト
- 全体テスト: ⚠️ tmux関連の環境依存テストを除きパス

### 確認事項
- [x] 実装計画に沿った実装
- [x] TDDアプローチでのテスト作成
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] 後方互換性の維持（旧セッション名もサポート）