### PR TITLE
feat: soba openコマンドの実装 (#55)

### DIFF
--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/douhashi/soba/internal/infra/tmux"
+)
+
+const defaultSessionName = "soba"
+
+type openCmd struct {
+	tmuxClient      tmux.TmuxClient
+	attachToSession func(sessionName string) error
+}
+
+func newOpenCmd() *cobra.Command {
+	o := &openCmd{
+		tmuxClient: tmux.NewClient(),
+	}
+	// デフォルトの実装を設定
+	o.attachToSession = o.defaultAttachToSession
+
+	cmd := &cobra.Command{
+		Use:   "open",
+		Short: "tmuxセッションを開く",
+		Long: `configから算出されるセッション名でtmuxセッションを開きます。
+
+既存のセッションが存在する場合はアタッチし、
+存在しない場合は新規作成してアタッチします。
+
+設定ファイルのgithub.repositoryからセッション名を自動算出します。`,
+		RunE: o.runOpen,
+	}
+
+	return cmd
+}
+
+func (o *openCmd) runOpen(cmd *cobra.Command, args []string) error {
+	repository := viper.GetString("github.repository")
+	sessionName := o.generateSessionName(repository)
+
+	if o.tmuxClient.SessionExists(sessionName) {
+		fmt.Printf("セッション '%s' にアタッチします\n", sessionName)
+		return o.attachToSession(sessionName)
+	}
+
+	fmt.Printf("セッション '%s' を作成します\n", sessionName)
+	if err := o.tmuxClient.CreateSession(sessionName); err != nil {
+		return fmt.Errorf("セッションの作成に失敗しました: %w", err)
+	}
+
+	return o.attachToSession(sessionName)
+}
+
+func (o *openCmd) generateSessionName(repository string) string {
+	if repository == "" {
+		return defaultSessionName
+	}
+
+	parts := strings.Split(repository, "/")
+	if len(parts) < 2 {
+		return defaultSessionName
+	}
+
+	// 空文字列の部分を除外
+	validParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			validParts = append(validParts, part)
+		}
+	}
+
+	if len(validParts) < 2 {
+		return defaultSessionName
+	}
+
+	return defaultSessionName + "-" + strings.Join(validParts, "-")
+}
+
+func (o *openCmd) defaultAttachToSession(sessionName string) error {
+	cmd := exec.Command("tmux", "attach-session", "-t", sessionName)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/internal/cli/open_test.go
+++ b/internal/cli/open_test.go
@@ -1,0 +1,221 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockTmuxClient はTmuxClientのモック実装
+type MockTmuxClient struct {
+	mock.Mock
+}
+
+func (m *MockTmuxClient) CreateSession(sessionName string) error {
+	args := m.Called(sessionName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) DeleteSession(sessionName string) error {
+	args := m.Called(sessionName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) SessionExists(sessionName string) bool {
+	args := m.Called(sessionName)
+	return args.Bool(0)
+}
+
+func (m *MockTmuxClient) CreateWindow(sessionName, windowName string) error {
+	args := m.Called(sessionName, windowName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) DeleteWindow(sessionName, windowName string) error {
+	args := m.Called(sessionName, windowName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) WindowExists(sessionName, windowName string) (bool, error) {
+	args := m.Called(sessionName, windowName)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockTmuxClient) CreatePane(sessionName, windowName string) error {
+	args := m.Called(sessionName, windowName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) DeletePane(sessionName, windowName string, paneIndex int) error {
+	args := m.Called(sessionName, windowName, paneIndex)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) GetPaneCount(sessionName, windowName string) (int, error) {
+	args := m.Called(sessionName, windowName)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockTmuxClient) GetFirstPaneIndex(sessionName, windowName string) (int, error) {
+	args := m.Called(sessionName, windowName)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockTmuxClient) GetLastPaneIndex(sessionName, windowName string) (int, error) {
+	args := m.Called(sessionName, windowName)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockTmuxClient) ResizePanes(sessionName, windowName string) error {
+	args := m.Called(sessionName, windowName)
+	return args.Error(0)
+}
+
+func (m *MockTmuxClient) SendCommand(sessionName, windowName string, paneIndex int, command string) error {
+	args := m.Called(sessionName, windowName, paneIndex, command)
+	return args.Error(0)
+}
+
+func TestGenerateSessionName(t *testing.T) {
+	tests := []struct {
+		name       string
+		repository string
+		expected   string
+	}{
+		{
+			name:       "正常なリポジトリ形式",
+			repository: "douhashi/soba",
+			expected:   "soba-douhashi-soba",
+		},
+		{
+			name:       "空のリポジトリ",
+			repository: "",
+			expected:   "soba",
+		},
+		{
+			name:       "不正な形式（スラッシュなし）",
+			repository: "invalid-repo",
+			expected:   "soba",
+		},
+		{
+			name:       "不正な形式（スラッシュのみ）",
+			repository: "/",
+			expected:   "soba",
+		},
+		{
+			name:       "長いリポジトリ名",
+			repository: "very-long-owner/very-long-repository-name",
+			expected:   "soba-very-long-owner-very-long-repository-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &openCmd{}
+			result := cmd.generateSessionName(tt.repository)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRunOpen_SessionExists(t *testing.T) {
+	mockTmux := new(MockTmuxClient)
+	cmd := &openCmd{
+		tmuxClient: mockTmux,
+		attachToSession: func(sessionName string) error {
+			// テスト環境では実際のtmux attachを実行せずに成功を返す
+			return nil
+		},
+	}
+
+	// 設定をセットアップ
+	viper.Set("github.repository", "douhashi/soba")
+
+	// セッションが既に存在する場合
+	mockTmux.On("SessionExists", "soba-douhashi-soba").Return(true)
+
+	err := cmd.runOpen(nil, []string{})
+
+	assert.NoError(t, err)
+	mockTmux.AssertExpectations(t)
+}
+
+func TestRunOpen_CreateNewSession(t *testing.T) {
+	mockTmux := new(MockTmuxClient)
+	cmd := &openCmd{
+		tmuxClient: mockTmux,
+		attachToSession: func(sessionName string) error {
+			// テスト環境では実際のtmux attachを実行せずに成功を返す
+			return nil
+		},
+	}
+
+	// 設定をセットアップ
+	viper.Set("github.repository", "douhashi/soba")
+
+	// セッションが存在しない場合
+	mockTmux.On("SessionExists", "soba-douhashi-soba").Return(false)
+	mockTmux.On("CreateSession", "soba-douhashi-soba").Return(nil)
+
+	err := cmd.runOpen(nil, []string{})
+
+	assert.NoError(t, err)
+	mockTmux.AssertExpectations(t)
+}
+
+func TestRunOpen_CreateSessionError(t *testing.T) {
+	mockTmux := new(MockTmuxClient)
+	cmd := &openCmd{
+		tmuxClient: mockTmux,
+		attachToSession: func(sessionName string) error {
+			// テスト環境では実際のtmux attachを実行せずに成功を返す
+			return nil
+		},
+	}
+
+	// 設定をセットアップ
+	viper.Set("github.repository", "douhashi/soba")
+
+	// セッション作成でエラーが発生する場合
+	mockTmux.On("SessionExists", "soba-douhashi-soba").Return(false)
+	mockTmux.On("CreateSession", "soba-douhashi-soba").Return(errors.New("tmux error"))
+
+	err := cmd.runOpen(nil, []string{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "セッションの作成に失敗しました")
+	mockTmux.AssertExpectations(t)
+}
+
+func TestRunOpen_NoRepository(t *testing.T) {
+	mockTmux := new(MockTmuxClient)
+	cmd := &openCmd{
+		tmuxClient: mockTmux,
+		attachToSession: func(sessionName string) error {
+			// テスト環境では実際のtmux attachを実行せずに成功を返す
+			return nil
+		},
+	}
+
+	// リポジトリが設定されていない場合
+	viper.Set("github.repository", "")
+
+	// デフォルトのセッション名を使用
+	mockTmux.On("SessionExists", "soba").Return(true)
+
+	err := cmd.runOpen(nil, []string{})
+
+	assert.NoError(t, err)
+	mockTmux.AssertExpectations(t)
+}
+
+func TestNewOpenCmd(t *testing.T) {
+	cmd := newOpenCmd()
+
+	assert.Equal(t, "open", cmd.Use)
+	assert.Equal(t, "tmuxセッションを開く", cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,6 +33,7 @@ development workflows through seamless integration with Claude Code AI.`,
 	cmd.AddCommand(newInitCmd())
 	cmd.AddCommand(newConfigCmd())
 	cmd.AddCommand(newStartCmd())
+	cmd.AddCommand(newOpenCmd())
 
 	return cmd
 }


### PR DESCRIPTION
## 実装完了

fixes #55

### 変更内容
- soba openコマンドを新規追加
- configから算出されるセッション名でtmuxセッションを開く機能を実装
- 既存セッションが存在する場合はアタッチ、存在しない場合は新規作成
- 既存のgenerateSessionNameロジックを活用したセッション名の自動算出

### 実装詳細
- `internal/cli/open.go`: openコマンドの実装
- `internal/cli/open_test.go`: 包括的なテストケース（TDD）
- `internal/cli/root.go`: openコマンドをrootコマンドに統合

### テスト結果
- 単体テスト: ✅ パス（openコマンド専用テスト含む）
- 全体テスト: ✅ パス（make test実行済み）
- カバレッジ: generateSessionName、runOpen、newOpenCmd全てテスト済み

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保（TDD実践）
- [x] 既存機能への影響なし
- [x] 既存アーキテクチャとの統合
- [x] エラーハンドリングの適切な実装

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>