### PR TITLE
refactor: remove unused setup_workspace configuration (#62)

### DIFF
--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -42,7 +42,6 @@ slack:
   notifications_enabled: false
 git:
   worktree_base_path: .git/soba/worktrees
-  setup_workspace: true
 phase:
   plan:
     command: plan.sh

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -166,7 +166,6 @@ func TestInitCommand(t *testing.T) {
 		assert.Equal(t, 20, loadedConfig.Workflow.Interval)
 		assert.True(t, loadedConfig.Workflow.UseTmux)
 		assert.Equal(t, ".git/soba/worktrees", loadedConfig.Git.WorktreeBasePath)
-		assert.True(t, loadedConfig.Git.SetupWorkspace)
 	})
 
 	t.Run("should create GitHub labels when config has repository info", func(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,6 @@ type SlackConfig struct {
 
 type GitConfig struct {
 	WorktreeBasePath string `yaml:"worktree_base_path"`
-	SetupWorkspace   bool   `yaml:"setup_workspace"`
 	BaseBranch       string `yaml:"base_branch"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,7 +31,6 @@ slack:
 
 git:
   worktree_base_path: .git/test/worktrees
-  setup_workspace: true
 
 phase:
   plan:
@@ -209,7 +208,6 @@ func TestConfigStructFields(t *testing.T) {
 		},
 		Git: GitConfig{
 			WorktreeBasePath: ".git/soba/worktrees",
-			SetupWorkspace:   true,
 		},
 		Phase: PhaseConfig{
 			Plan: PhaseCommand{

--- a/internal/config/display_test.go
+++ b/internal/config/display_test.go
@@ -120,7 +120,6 @@ func TestDisplayConfig(t *testing.T) {
 		},
 		Git: GitConfig{
 			WorktreeBasePath: ".git/soba/worktrees",
-			SetupWorkspace:   true,
 		},
 		Phase: PhaseConfig{
 			Plan: PhaseCommand{

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -60,8 +60,6 @@ slack:
 git:
   # Base path for git worktrees
   worktree_base_path: .git/soba/worktrees
-  # Auto-setup workspace on phase start (default: true)
-  setup_workspace: true
 
 # Phase commands (optional - for custom Claude commands)
 phase:

--- a/internal/config/template_test.go
+++ b/internal/config/template_test.go
@@ -42,7 +42,7 @@ func TestGenerateTemplate(t *testing.T) {
 		assert.Contains(t, template, "closed_issue_cleanup_interval: 300")
 		assert.Contains(t, template, "tmux_command_delay: 3")
 		assert.Contains(t, template, "notifications_enabled: false")
-		assert.Contains(t, template, "setup_workspace: true")
+		assert.NotContains(t, template, "setup_workspace")
 		assert.Contains(t, template, "worktree_base_path: .git/soba/worktrees")
 	})
 
@@ -102,7 +102,6 @@ func TestGenerateTemplate(t *testing.T) {
 		assert.Equal(t, 300, config.Workflow.ClosedIssueCleanupInterval)
 		assert.Equal(t, 3, config.Workflow.TmuxCommandDelay)
 		assert.False(t, config.Slack.NotificationsEnabled)
-		assert.True(t, config.Git.SetupWorkspace)
 		assert.Equal(t, ".git/soba/worktrees", config.Git.WorktreeBasePath)
 
 		// Verify phase commands


### PR DESCRIPTION
## 実装完了

fixes #62

### 変更内容
- config templateから`setup_workspace`設定を削除
- GitConfig構造体から`SetupWorkspace`フィールドを削除
- 関連する全てのテストケースを更新

### 調査結果
- `SetupWorkspace`フィールドは実際には使用されていないことを確認
- worktree作成はPhaseDefinitionの`RequiresWorktree`フラグで制御されている
- 既存のworktree機能への影響はない

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス (`go test ./...` 全て成功)
- ビルド: ✅ 成功 (`go build ./...` エラーなし)

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] 後方互換性の考慮（YAMLパーサーは未知のフィールドを無視するため、古い設定ファイルも正常に読み込み可能）