### PR TITLE
fix: ログファイルへのログ出力が動作しない問題を修正 (#82)

### DIFF
--- a/pkg/logger/file_writer.go
+++ b/pkg/logger/file_writer.go
@@ -9,13 +9,24 @@ import (
 )
 
 type FileWriter struct {
-	path string
-	file *os.File
-	mu   sync.Mutex
+	path      string
+	file      *os.File
+	autoFlush bool
+	mu        sync.Mutex
+}
+
+// FileWriterOption defines options for FileWriter
+type FileWriterOption func(*FileWriter)
+
+// WithAutoFlush sets the autoFlush option
+func WithAutoFlush(autoFlush bool) FileWriterOption {
+	return func(fw *FileWriter) {
+		fw.autoFlush = autoFlush
+	}
 }
 
 // NewFileWriter creates a new FileWriter with the specified path
-func NewFileWriter(path string) (*FileWriter, error) {
+func NewFileWriter(path string, opts ...FileWriterOption) (*FileWriter, error) {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create log directory: %w", err)
@@ -26,10 +37,18 @@ func NewFileWriter(path string) (*FileWriter, error) {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
 
-	return &FileWriter{
-		path: path,
-		file: file,
-	}, nil
+	fw := &FileWriter{
+		path:      path,
+		file:      file,
+		autoFlush: true, // Default to true
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(fw)
+	}
+
+	return fw, nil
 }
 
 // Write implements io.Writer interface
@@ -41,7 +60,30 @@ func (fw *FileWriter) Write(p []byte) (n int, err error) {
 		return 0, fmt.Errorf("file writer is closed")
 	}
 
-	return fw.file.Write(p)
+	n, err = fw.file.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	if fw.autoFlush {
+		if syncErr := fw.file.Sync(); syncErr != nil {
+			return n, syncErr
+		}
+	}
+
+	return n, nil
+}
+
+// Sync flushes the file buffer to disk
+func (fw *FileWriter) Sync() error {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+
+	if fw.file == nil {
+		return fmt.Errorf("file writer is closed")
+	}
+
+	return fw.file.Sync()
 }
 
 // Close closes the underlying file
@@ -51,6 +93,12 @@ func (fw *FileWriter) Close() error {
 
 	if fw.file == nil {
 		return nil
+	}
+
+	// Sync before closing to ensure all data is written
+	if syncErr := fw.file.Sync(); syncErr != nil {
+		// Log sync error but still try to close
+		fmt.Fprintf(os.Stderr, "Warning: failed to sync before close: %v\n", syncErr)
 	}
 
 	err := fw.file.Close()

--- a/pkg/logger/file_writer_test.go
+++ b/pkg/logger/file_writer_test.go
@@ -89,3 +89,130 @@ func TestFileWriterPermissionError(t *testing.T) {
 		t.Errorf("Expected permission error, got nil")
 	}
 }
+
+func TestFileWriterSync(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	fw, err := NewFileWriter(logPath)
+	if err != nil {
+		t.Fatalf("Failed to create FileWriter: %v", err)
+	}
+	defer fw.Close()
+
+	testData := []byte("test sync message\n")
+	_, err = fw.Write(testData)
+	if err != nil {
+		t.Fatalf("Failed to write to log file: %v", err)
+	}
+
+	// Sync()を呼び出し
+	err = fw.Sync()
+	if err != nil {
+		t.Fatalf("Failed to sync: %v", err)
+	}
+
+	// ファイルの内容を確認
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+
+	if string(content) != string(testData) {
+		t.Errorf("File content = %q, want %q", string(content), string(testData))
+	}
+}
+
+func TestFileWriterAutoFlush(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	// AutoFlushを有効にして作成
+	fw, err := NewFileWriter(logPath, WithAutoFlush(true))
+	if err != nil {
+		t.Fatalf("Failed to create FileWriter: %v", err)
+	}
+	defer fw.Close()
+
+	testData := []byte("auto flush message\n")
+	_, err = fw.Write(testData)
+	if err != nil {
+		t.Fatalf("Failed to write to log file: %v", err)
+	}
+
+	// AutoFlushが有効なので、即座にファイルに書き込まれているはず
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+
+	if string(content) != string(testData) {
+		t.Errorf("File content = %q, want %q", string(content), string(testData))
+	}
+}
+
+func TestFileWriterAutoFlushDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	// AutoFlushを無効にして作成
+	fw, err := NewFileWriter(logPath, WithAutoFlush(false))
+	if err != nil {
+		t.Fatalf("Failed to create FileWriter: %v", err)
+	}
+	defer fw.Close()
+
+	testData := []byte("no auto flush message\n")
+	_, err = fw.Write(testData)
+	if err != nil {
+		t.Fatalf("Failed to write to log file: %v", err)
+	}
+
+	// 明示的にSync()を呼ぶまで、バッファリングされている可能性がある
+	// ただし、OSのバッファリング動作に依存するため、
+	// ここでは明示的なSync()後に確実に書き込まれることを確認
+	err = fw.Sync()
+	if err != nil {
+		t.Fatalf("Failed to sync: %v", err)
+	}
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+
+	if string(content) != string(testData) {
+		t.Errorf("File content = %q, want %q", string(content), string(testData))
+	}
+}
+
+func TestFileWriterCloseWithSync(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	fw, err := NewFileWriter(logPath, WithAutoFlush(false))
+	if err != nil {
+		t.Fatalf("Failed to create FileWriter: %v", err)
+	}
+
+	testData := []byte("close with sync message\n")
+	_, err = fw.Write(testData)
+	if err != nil {
+		t.Fatalf("Failed to write to log file: %v", err)
+	}
+
+	// Close時にSync()が呼ばれることを確認
+	err = fw.Close()
+	if err != nil {
+		t.Fatalf("Failed to close: %v", err)
+	}
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+
+	if string(content) != string(testData) {
+		t.Errorf("File content = %q, want %q", string(content), string(testData))
+	}
+}


### PR DESCRIPTION
## 実装完了

fixes #82

### 変更内容
- FileWriterにSync()メソッドとautoFlushオプションを追加
- Write操作後に自動的にSync()を呼び出すautoFlush機能を実装（デフォルト有効）
- Close()時にもSync()を呼び出してバッファをフラッシュ
- NewFileWriterをオプションパターンで拡張し、後方互換性を維持

### テスト結果
- 単体テスト: ✅ パス
  - AutoFlushの動作確認テストを追加
  - Sync()メソッドの単体テストを追加
  - Close()時のSync呼び出し確認テストを追加
- 全体テスト: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] ログファイルにログが即座に出力されることを確認