### PR TITLE
fix: ログファイルへのログ出力が動作しない問題を修正

### DIFF
--- a/internal/service/daemon.go
+++ b/internal/service/daemon.go
@@ -164,6 +164,7 @@ func (d *daemonService) initializeLogging(cfg *config.Config) (string, error) {
 	if err := logger.InitWithFile(logger.Config{
 		Environment: "production",
 		Level:       logger.ParseLevel(os.Getenv("LOG_LEVEL")),
+		Output:      os.Stdout,
 		FilePath:    logPath,
 	}); err != nil {
 		log.Error("Failed to initialize log file", "error", err, "path", logPath)
@@ -185,13 +186,14 @@ func (d *daemonService) initializeLogging(cfg *config.Config) (string, error) {
 
 // StartForeground starts Issue monitoring in foreground mode
 func (d *daemonService) StartForeground(ctx context.Context, cfg *config.Config) error {
-	log := logger.NewLogger(logger.GetLogger())
-
 	// ログ出力を初期化（foregroundモードでもログファイルへ出力）
 	logPath, err := d.initializeLogging(cfg)
 	if err != nil {
 		return err
 	}
+
+	// ログ初期化後に新しいロガーインスタンスを作成（ファイル出力設定を含む）
+	log := logger.NewLogger(logger.GetLogger())
 
 	if logPath != "" {
 		log.Info("Starting Issue monitoring in foreground mode", "logFile", logPath)
@@ -293,8 +295,6 @@ const envValueTrue = "true"
 
 // StartDaemon starts Issue monitoring in daemon mode
 func (d *daemonService) StartDaemon(ctx context.Context, cfg *config.Config) error {
-	log := logger.NewLogger(logger.GetLogger())
-
 	// 既に実行中かチェック
 	if d.IsRunning() {
 		return errors.NewConflictError("daemon is already running")
@@ -312,6 +312,9 @@ func (d *daemonService) StartDaemon(ctx context.Context, cfg *config.Config) err
 	if err != nil {
 		return err
 	}
+
+	// ログ初期化後に新しいロガーインスタンスを作成（ファイル出力設定を含む）
+	log := logger.NewLogger(logger.GetLogger())
 
 	// tmuxセッションを初期化
 	if err := d.initializeTmuxSession(cfg); err != nil {


### PR DESCRIPTION
## 概要
`bin/soba start`実行時にログファイルへのログ出力が動作しない問題を修正しました。

## 問題
- `bin/soba start`を実行すると、ログファイルは作成されるがログが出力されない
- 標準出力にはログが正しく出力される

## 原因
1. `InitWithFile`呼び出し時に`Output`パラメータ（`os.Stdout`）が未指定だった
2. ロガー初期化の順序問題（ファイル出力設定前のロガーインスタンスを使用していた）

## 修正内容
- `daemon.go`の`InitWithFile`に`Output: os.Stdout`を追加
- `StartForeground`/`StartDaemon`メソッドで、ログ初期化後に新しいロガーインスタンスを作成するよう順序を変更

## テスト方法
1. `bin/soba start`を実行
2. `.soba/logs/`ディレクトリ内のログファイルを確認
3. 標準出力とログファイルの両方に同じログが出力されることを確認

## 確認項目
- [x] テスト実行済み（全てのテストがパス）
- [x] Lint実行済み（エラーなし）
- [x] 実際に動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)