### PR TITLE
feat: フォアグラウンドモードで標準出力とログファイルの両方に出力

### DIFF
--- a/internal/service/daemon_test.go
+++ b/internal/service/daemon_test.go
@@ -552,7 +552,7 @@ func TestDaemonService_InitializeLogging(t *testing.T) {
 				logger:  mockLogger,
 			}
 
-			logPath, err := service.initializeLogging(tt.cfg)
+			logPath, err := service.initializeLogging(tt.cfg, false)
 
 			if tt.wantError {
 				assert.Error(t, err)

--- a/pkg/logging/factory.go
+++ b/pkg/logging/factory.go
@@ -10,11 +10,12 @@ import (
 
 // Config represents logger configuration
 type Config struct {
-	Level      string
-	Format     string // "json" or "text"
-	Output     string // "stdout", "stderr", or file path
-	AddSource  bool
-	TimeFormat string
+	Level        string
+	Format       string // "json" or "text"
+	Output       string // "stdout", "stderr", or file path
+	AddSource    bool
+	TimeFormat   string
+	AlsoToStdout bool // Also output to stdout when Output is a file path
 }
 
 // Factory creates logger instances with consistent configuration
@@ -38,7 +39,13 @@ func NewFactory(cfg Config) (*Factory, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create file writer: %w", err)
 		}
-		writer = fw
+
+		// If AlsoToStdout is true, create a MultiWriter that writes to both file and stdout
+		if cfg.AlsoToStdout {
+			writer = MultiWriter(fw, os.Stdout)
+		} else {
+			writer = fw
+		}
 	}
 
 	level := parseLevel(cfg.Level)

--- a/pkg/logging/multi_writer.go
+++ b/pkg/logging/multi_writer.go
@@ -1,0 +1,10 @@
+package logging
+
+import (
+	"io"
+)
+
+// MultiWriter creates a writer that duplicates its writes to all the provided writers
+func MultiWriter(writers ...io.Writer) io.Writer {
+	return io.MultiWriter(writers...)
+}


### PR DESCRIPTION
## 概要
フォアグラウンドモードでの実行時、ログを標準出力とログファイルの両方に同時出力するように改善しました。

## 変更内容
- `MultiWriter`を追加して複数の出力先への同時書き込みをサポート
- `logging.Config`に`AlsoToStdout`フラグを追加
- フォアグラウンドモードでは`AlsoToStdout=true`でログを初期化
- デーモンモードでは従来通りファイルのみに出力

## 動作確認
- [x] フォアグラウンドモードで標準出力にログが表示される
- [x] フォアグラウンドモードでログファイルにも同時に記録される
- [x] デーモンモードではファイルのみに出力される
- [x] 全テスト合格

## メリット
フォアグラウンドモードでリアルタイムにログを確認しながら、同時にログファイルにも記録されるようになり、デバッグが容易になります。

🤖 Generated with [Claude Code](https://claude.ai/code)