### PR TITLE
fix: フェーズラベル遷移とIssueProcessor設定の修正

### DIFF
--- a/internal/domain/phase.go
+++ b/internal/domain/phase.go
@@ -218,7 +218,7 @@ func GetCurrentPhaseFromLabels(labels []string) (Phase, error) {
 	// review-requestedやrequires-changesなど、複数のフェーズで使われるラベルがある
 	switch sobaLabel {
 	case LabelReady:
-		return PhasePlan, nil // readyはplanの完了後
+		return PhaseImplement, nil // readyはimplementフェーズのトリガー
 	case LabelReviewRequested:
 		// review-requestedはimplementまたはreviseの完了後
 		// この場合、Reviewフェーズとみなす

--- a/internal/domain/phase_test.go
+++ b/internal/domain/phase_test.go
@@ -1,0 +1,122 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/douhashi/soba/internal/domain"
+)
+
+func TestGetCurrentPhaseFromLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        []string
+		expectedPhase domain.Phase
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name:          "soba:todoラベルがある場合はqueueフェーズ",
+			labels:        []string{"soba:todo", "bug", "enhancement"},
+			expectedPhase: domain.PhaseQueue,
+		},
+		{
+			name:          "soba:queuedラベルがある場合はplanフェーズ",
+			labels:        []string{"soba:queued", "bug"},
+			expectedPhase: domain.PhasePlan,
+		},
+		{
+			name:          "soba:planningラベルがある場合はplanフェーズ（実行中）",
+			labels:        []string{"soba:planning", "enhancement"},
+			expectedPhase: domain.PhasePlan,
+		},
+		{
+			name:          "soba:readyラベルがある場合はimplementフェーズ",
+			labels:        []string{"soba:ready", "feature"},
+			expectedPhase: domain.PhaseImplement,
+		},
+		{
+			name:          "soba:doingラベルがある場合はimplementフェーズ（実行中）",
+			labels:        []string{"soba:doing", "bug"},
+			expectedPhase: domain.PhaseImplement,
+		},
+		{
+			name:          "soba:review-requestedラベルがある場合はreviewフェーズ",
+			labels:        []string{"soba:review-requested", "enhancement"},
+			expectedPhase: domain.PhaseReview,
+		},
+		{
+			name:          "soba:reviewingラベルがある場合はreviewフェーズ（実行中）",
+			labels:        []string{"soba:reviewing"},
+			expectedPhase: domain.PhaseReview,
+		},
+		{
+			name:          "soba:doneラベルがある場合はreviewフェーズ（完了）",
+			labels:        []string{"soba:done", "enhancement"},
+			expectedPhase: domain.PhaseReview,
+		},
+		{
+			name:          "soba:requires-changesラベルがある場合はreviseフェーズ",
+			labels:        []string{"soba:requires-changes"},
+			expectedPhase: domain.PhaseRevise,
+		},
+		{
+			name:          "soba:revisingラベルがある場合はreviseフェーズ（実行中）",
+			labels:        []string{"soba:revising", "bug"},
+			expectedPhase: domain.PhaseRevise,
+		},
+		{
+			name:          "soba:lgtmラベルは無視される（他のsobaラベルがある場合）",
+			labels:        []string{"soba:ready", "soba:lgtm", "feature"},
+			expectedPhase: domain.PhaseImplement,
+		},
+		{
+			name:          "sobaラベルがない場合はエラー",
+			labels:        []string{"bug", "enhancement"},
+			expectedError: true,
+			errorContains: "no soba label found",
+		},
+		{
+			name:          "複数のsobaラベルがある場合はエラー（LGTMを除く）",
+			labels:        []string{"soba:todo", "soba:ready", "bug"},
+			expectedError: true,
+			errorContains: "multiple soba labels found",
+		},
+		{
+			name:          "不明なsobaラベルがある場合はエラー",
+			labels:        []string{"soba:unknown", "bug"},
+			expectedError: true,
+			errorContains: "unknown soba label: soba:unknown",
+		},
+		{
+			name:          "空のラベルリストの場合はエラー",
+			labels:        []string{},
+			expectedError: true,
+			errorContains: "no soba label found",
+		},
+		{
+			name:          "soba:lgtmのみの場合はエラー",
+			labels:        []string{"soba:lgtm"},
+			expectedError: true,
+			errorContains: "no soba label found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			phase, err := domain.GetCurrentPhaseFromLabels(tt.labels)
+
+			if tt.expectedError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedPhase, phase)
+			}
+		})
+	}
+}

--- a/internal/infra/slack/notifier.go
+++ b/internal/infra/slack/notifier.go
@@ -51,6 +51,15 @@ func (n *Notifier) NotifyPRMerged(prNumber, issueNumber int) error {
 	return n.sendAsync(message)
 }
 
+func (n *Notifier) NotifyError(title, errorMessage string) error {
+	if !n.config.NotificationsEnabled {
+		return nil
+	}
+
+	message := fmt.Sprintf("❌ エラー: %s\n%s", title, errorMessage)
+	return n.sendAsync(message)
+}
+
 func (n *Notifier) sendAsync(message string) error {
 	if n.async {
 		go func() {

--- a/internal/service/builder/dependency_resolver.go
+++ b/internal/service/builder/dependency_resolver.go
@@ -160,8 +160,9 @@ func (r *DependencyResolver) ResolveServices(ctx context.Context, clients *Resol
 
 	// Phase 4: Update workflow executor with processor
 	r.logger.Debug(ctx, "Updating workflow executor with processor")
-	// Note: SetIssueProcessor has been removed from the interface
-	// The processor should be passed through constructor or configuration
+	// Set the issue processor on the workflow executor
+	workflowExecutor.SetIssueProcessor(issueProcessor)
+	r.logger.Info(ctx, "Successfully set IssueProcessor on WorkflowExecutor")
 
 	// Parse repository for owner and repo (needed for multiple services)
 	owner, repo := parseRepository(r.config.GitHub.Repository)

--- a/internal/service/builder/interfaces.go
+++ b/internal/service/builder/interfaces.go
@@ -30,6 +30,7 @@ type IssueProcessorUpdater interface {
 // WorkflowExecutor executes workflow phases
 type WorkflowExecutor interface {
 	ExecutePhase(ctx context.Context, cfg *config.Config, issueNumber int, phase interface{}) error
+	SetIssueProcessor(processor IssueProcessorUpdater)
 }
 
 // IssueWatcher watches for issue changes


### PR DESCRIPTION
## Summary
- readyラベルの判定をPlanフェーズからImplementフェーズに修正
- WorkflowExecutorインターフェースにSetIssueProcessorメソッドを追加
- DependencyResolverでIssueProcessorの設定処理を復元

## Changes
- `GetCurrentPhaseFromLabels`関数でreadyラベルをimplementフェーズのトリガーとして正しく判定
- WorkflowExecutorへのIssueProcessor設定処理を復元し、ラベル更新機能を有効化
- フェーズラベル遷移のテストケースを追加

## Test plan
- [x] 全てのユニットテストがパス (`go test -v ./...`)
- [x] readyラベルの判定が正しく動作することを確認
- [x] WorkflowExecutorでIssueProcessorが正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)