### PR TITLE
feat: shouldWarnForEnvVar 実装をStrategyパターンでリファクタリング (#91)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,21 +113,10 @@ func expandEnvVarsWithConfig(content string, cfg *Config) string {
 }
 
 // shouldWarnForEnvVar determines if a warning should be shown for a missing environment variable
+// This function uses the EnvVarClassifier to categorize variables and apply appropriate warning logic
 func shouldWarnForEnvVar(key string, cfg *Config) bool {
-	switch key {
-	case "GITHUB_TOKEN":
-		// Warn only when auth_method is "env"
-		return cfg.GitHub.AuthMethod == "env"
-	case "SLACK_WEBHOOK_URL":
-		// Warn only when notifications_enabled is true
-		return cfg.Slack.NotificationsEnabled
-	case "PID":
-		// PID is a special variable replaced at daemon startup, not during config load
-		return false
-	default:
-		// For other environment variables, always warn (preserve existing behavior)
-		return true
-	}
+	classifier := NewEnvVarClassifier()
+	return classifier.ShouldWarn(key, cfg)
 }
 
 func (c *Config) setDefaults() {

--- a/internal/config/env_var_classifier.go
+++ b/internal/config/env_var_classifier.go
@@ -1,0 +1,107 @@
+package config
+
+// EnvVarCategory represents the category of an environment variable
+type EnvVarCategory int
+
+const (
+	// SystemVariable represents system-managed variables that should never warn
+	SystemVariable EnvVarCategory = iota
+	// ConditionalVariable represents variables that warn based on configuration
+	ConditionalVariable
+	// UserVariable represents user-defined variables that always warn when undefined
+	UserVariable
+)
+
+// String returns the string representation of the category
+func (c EnvVarCategory) String() string {
+	switch c {
+	case SystemVariable:
+		return "system"
+	case ConditionalVariable:
+		return "conditional"
+	case UserVariable:
+		return "user"
+	default:
+		return "unknown"
+	}
+}
+
+// EnvVarClassifier is an interface for classifying environment variables
+type EnvVarClassifier interface {
+	// Classify determines the category of an environment variable
+	Classify(envVar string, cfg *Config) EnvVarCategory
+	// ShouldWarn determines if a warning should be shown for a missing environment variable
+	ShouldWarn(envVar string, cfg *Config) bool
+}
+
+// defaultEnvVarClassifier is the default implementation of EnvVarClassifier
+type defaultEnvVarClassifier struct{}
+
+// NewEnvVarClassifier creates a new EnvVarClassifier instance
+func NewEnvVarClassifier() EnvVarClassifier {
+	return &defaultEnvVarClassifier{}
+}
+
+// Classify determines the category of an environment variable
+func (c *defaultEnvVarClassifier) Classify(envVar string, cfg *Config) EnvVarCategory {
+	if c.isSystemVariable(envVar) {
+		return SystemVariable
+	}
+	if c.isConditionalVariable(envVar) {
+		return ConditionalVariable
+	}
+	return UserVariable
+}
+
+// ShouldWarn determines if a warning should be shown for a missing environment variable
+func (c *defaultEnvVarClassifier) ShouldWarn(envVar string, cfg *Config) bool {
+	category := c.Classify(envVar, cfg)
+
+	switch category {
+	case SystemVariable:
+		// System variables never warn
+		return false
+	case ConditionalVariable:
+		// Conditional variables warn based on configuration
+		return c.shouldWarnForConditionalVariable(envVar, cfg)
+	case UserVariable:
+		// User variables always warn
+		return true
+	default:
+		// Unknown category defaults to warning
+		return true
+	}
+}
+
+// isSystemVariable checks if an environment variable is a system variable
+func (c *defaultEnvVarClassifier) isSystemVariable(envVar string) bool {
+	// Currently only PID is treated as a system variable
+	// It's replaced at daemon startup, not during config load
+	return envVar == "PID"
+}
+
+// isConditionalVariable checks if an environment variable is a conditional variable
+func (c *defaultEnvVarClassifier) isConditionalVariable(envVar string) bool {
+	// These variables have conditional warning logic based on configuration
+	switch envVar {
+	case "GITHUB_TOKEN", "SLACK_WEBHOOK_URL":
+		return true
+	default:
+		return false
+	}
+}
+
+// shouldWarnForConditionalVariable determines if a conditional variable should warn
+func (c *defaultEnvVarClassifier) shouldWarnForConditionalVariable(envVar string, cfg *Config) bool {
+	switch envVar {
+	case "GITHUB_TOKEN":
+		// Warn only when auth_method is "env"
+		return cfg.GitHub.AuthMethod == "env"
+	case "SLACK_WEBHOOK_URL":
+		// Warn only when notifications_enabled is true
+		return cfg.Slack.NotificationsEnabled
+	default:
+		// Unknown conditional variable defaults to no warning
+		return false
+	}
+}

--- a/internal/config/env_var_classifier_test.go
+++ b/internal/config/env_var_classifier_test.go
@@ -1,0 +1,345 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestEnvVarCategoryString(t *testing.T) {
+	tests := []struct {
+		category EnvVarCategory
+		expected string
+	}{
+		{SystemVariable, "system"},
+		{ConditionalVariable, "conditional"},
+		{UserVariable, "user"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.category.String(); got != tt.expected {
+				t.Errorf("EnvVarCategory.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClassifyEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVar   string
+		config   *Config
+		expected EnvVarCategory
+	}{
+		{
+			name:     "PID is system variable",
+			envVar:   "PID",
+			config:   &Config{},
+			expected: SystemVariable,
+		},
+		{
+			name:     "GITHUB_TOKEN is conditional variable",
+			envVar:   "GITHUB_TOKEN",
+			config:   &Config{},
+			expected: ConditionalVariable,
+		},
+		{
+			name:     "SLACK_WEBHOOK_URL is conditional variable",
+			envVar:   "SLACK_WEBHOOK_URL",
+			config:   &Config{},
+			expected: ConditionalVariable,
+		},
+		{
+			name:     "Custom variable is user variable",
+			envVar:   "CUSTOM_VAR",
+			config:   &Config{},
+			expected: UserVariable,
+		},
+		{
+			name:     "Empty string is user variable",
+			envVar:   "",
+			config:   &Config{},
+			expected: UserVariable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			classifier := NewEnvVarClassifier()
+			if got := classifier.Classify(tt.envVar, tt.config); got != tt.expected {
+				t.Errorf("EnvVarClassifier.Classify(%q) = %v, want %v", tt.envVar, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultEnvVarClassifier_ShouldWarn(t *testing.T) {
+	tests := []struct {
+		name       string
+		envVar     string
+		config     *Config
+		shouldWarn bool
+	}{
+		{
+			name:       "System variable PID never warns",
+			envVar:     "PID",
+			config:     &Config{},
+			shouldWarn: false,
+		},
+		{
+			name:   "GITHUB_TOKEN warns when auth_method is env",
+			envVar: "GITHUB_TOKEN",
+			config: &Config{
+				GitHub: GitHubConfig{AuthMethod: "env"},
+			},
+			shouldWarn: true,
+		},
+		{
+			name:   "GITHUB_TOKEN does not warn when auth_method is gh",
+			envVar: "GITHUB_TOKEN",
+			config: &Config{
+				GitHub: GitHubConfig{AuthMethod: "gh"},
+			},
+			shouldWarn: false,
+		},
+		{
+			name:   "GITHUB_TOKEN does not warn when auth_method is token",
+			envVar: "GITHUB_TOKEN",
+			config: &Config{
+				GitHub: GitHubConfig{AuthMethod: "token"},
+			},
+			shouldWarn: false,
+		},
+		{
+			name:   "SLACK_WEBHOOK_URL warns when notifications_enabled is true",
+			envVar: "SLACK_WEBHOOK_URL",
+			config: &Config{
+				Slack: SlackConfig{NotificationsEnabled: true},
+			},
+			shouldWarn: true,
+		},
+		{
+			name:   "SLACK_WEBHOOK_URL does not warn when notifications_enabled is false",
+			envVar: "SLACK_WEBHOOK_URL",
+			config: &Config{
+				Slack: SlackConfig{NotificationsEnabled: false},
+			},
+			shouldWarn: false,
+		},
+		{
+			name:       "User variable always warns",
+			envVar:     "CUSTOM_VAR",
+			config:     &Config{},
+			shouldWarn: true,
+		},
+		{
+			name:       "Unknown variable always warns",
+			envVar:     "UNKNOWN_VAR",
+			config:     &Config{},
+			shouldWarn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			classifier := NewEnvVarClassifier()
+			if got := classifier.ShouldWarn(tt.envVar, tt.config); got != tt.shouldWarn {
+				t.Errorf("EnvVarClassifier.ShouldWarn(%q) = %v, want %v", tt.envVar, got, tt.shouldWarn)
+			}
+		})
+	}
+}
+
+func TestIsSystemVariable(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVar string
+		want   bool
+	}{
+		{"PID is system variable", "PID", true},
+		{"pid lowercase is not system variable", "pid", false},
+		{"GITHUB_TOKEN is not system variable", "GITHUB_TOKEN", false},
+		{"SLACK_WEBHOOK_URL is not system variable", "SLACK_WEBHOOK_URL", false},
+		{"CUSTOM_VAR is not system variable", "CUSTOM_VAR", false},
+		{"Empty string is not system variable", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			classifier := &defaultEnvVarClassifier{}
+			if got := classifier.isSystemVariable(tt.envVar); got != tt.want {
+				t.Errorf("isSystemVariable(%q) = %v, want %v", tt.envVar, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsConditionalVariable(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVar string
+		want   bool
+	}{
+		{"GITHUB_TOKEN is conditional", "GITHUB_TOKEN", true},
+		{"SLACK_WEBHOOK_URL is conditional", "SLACK_WEBHOOK_URL", true},
+		{"PID is not conditional", "PID", false},
+		{"CUSTOM_VAR is not conditional", "CUSTOM_VAR", false},
+		{"github_token lowercase is not conditional", "github_token", false},
+		{"Empty string is not conditional", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			classifier := &defaultEnvVarClassifier{}
+			if got := classifier.isConditionalVariable(tt.envVar); got != tt.want {
+				t.Errorf("isConditionalVariable(%q) = %v, want %v", tt.envVar, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldWarnForConditionalVariable(t *testing.T) {
+	tests := []struct {
+		name       string
+		envVar     string
+		config     *Config
+		shouldWarn bool
+	}{
+		{
+			name:   "GITHUB_TOKEN warns with auth_method=env",
+			envVar: "GITHUB_TOKEN",
+			config: &Config{
+				GitHub: GitHubConfig{AuthMethod: "env"},
+			},
+			shouldWarn: true,
+		},
+		{
+			name:   "GITHUB_TOKEN no warn with auth_method=gh",
+			envVar: "GITHUB_TOKEN",
+			config: &Config{
+				GitHub: GitHubConfig{AuthMethod: "gh"},
+			},
+			shouldWarn: false,
+		},
+		{
+			name:   "SLACK_WEBHOOK_URL warns with notifications_enabled=true",
+			envVar: "SLACK_WEBHOOK_URL",
+			config: &Config{
+				Slack: SlackConfig{NotificationsEnabled: true},
+			},
+			shouldWarn: true,
+		},
+		{
+			name:   "SLACK_WEBHOOK_URL no warn with notifications_enabled=false",
+			envVar: "SLACK_WEBHOOK_URL",
+			config: &Config{
+				Slack: SlackConfig{NotificationsEnabled: false},
+			},
+			shouldWarn: false,
+		},
+		{
+			name:       "Unknown conditional variable defaults to no warning",
+			envVar:     "UNKNOWN_CONDITIONAL",
+			config:     &Config{},
+			shouldWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			classifier := &defaultEnvVarClassifier{}
+			if got := classifier.shouldWarnForConditionalVariable(tt.envVar, tt.config); got != tt.shouldWarn {
+				t.Errorf("shouldWarnForConditionalVariable(%q) = %v, want %v", tt.envVar, got, tt.shouldWarn)
+			}
+		})
+	}
+}
+
+// TestShouldWarnForEnvVarWithClassifier tests the refactored shouldWarnForEnvVar function
+func TestShouldWarnForEnvVarWithClassifier(t *testing.T) {
+	tests := []struct {
+		name       string
+		envVar     string
+		config     *Config
+		shouldWarn bool
+	}{
+		// System variables
+		{
+			name:       "PID never warns",
+			envVar:     "PID",
+			config:     &Config{},
+			shouldWarn: false,
+		},
+		// Conditional variables - GITHUB_TOKEN
+		{
+			name:   "GITHUB_TOKEN warns when auth_method is env",
+			envVar: "GITHUB_TOKEN",
+			config: &Config{
+				GitHub: GitHubConfig{AuthMethod: "env"},
+			},
+			shouldWarn: true,
+		},
+		{
+			name:   "GITHUB_TOKEN no warn when auth_method is gh",
+			envVar: "GITHUB_TOKEN",
+			config: &Config{
+				GitHub: GitHubConfig{AuthMethod: "gh"},
+			},
+			shouldWarn: false,
+		},
+		{
+			name:   "GITHUB_TOKEN no warn when auth_method is token",
+			envVar: "GITHUB_TOKEN",
+			config: &Config{
+				GitHub: GitHubConfig{AuthMethod: "token"},
+			},
+			shouldWarn: false,
+		},
+		// Conditional variables - SLACK_WEBHOOK_URL
+		{
+			name:   "SLACK_WEBHOOK_URL warns when notifications_enabled is true",
+			envVar: "SLACK_WEBHOOK_URL",
+			config: &Config{
+				Slack: SlackConfig{NotificationsEnabled: true},
+			},
+			shouldWarn: true,
+		},
+		{
+			name:   "SLACK_WEBHOOK_URL no warn when notifications_enabled is false",
+			envVar: "SLACK_WEBHOOK_URL",
+			config: &Config{
+				Slack: SlackConfig{NotificationsEnabled: false},
+			},
+			shouldWarn: false,
+		},
+		// User variables
+		{
+			name:       "User variable always warns",
+			envVar:     "CUSTOM_VAR",
+			config:     &Config{},
+			shouldWarn: true,
+		},
+		{
+			name:       "Another user variable always warns",
+			envVar:     "MY_APP_CONFIG",
+			config:     &Config{},
+			shouldWarn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test using new classifier directly
+			classifier := NewEnvVarClassifier()
+			got := classifier.ShouldWarn(tt.envVar, tt.config)
+			if got != tt.shouldWarn {
+				t.Errorf("EnvVarClassifier.ShouldWarn(%q) = %v, want %v", tt.envVar, got, tt.shouldWarn)
+			}
+
+			// Also test the original shouldWarnForEnvVar function (for backwards compatibility)
+			originalGot := shouldWarnForEnvVar(tt.envVar, tt.config)
+			if originalGot != tt.shouldWarn {
+				t.Errorf("shouldWarnForEnvVar(%q) = %v, want %v", tt.envVar, originalGot, tt.shouldWarn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 実装完了

fixes #91

### 変更内容
- shouldWarnForEnvVar関数をStrategyパターンでリファクタリング
- 環境変数を3つのカテゴリに明確に分類（System、Conditional、User）
- EnvVarClassifierインターフェースによる拡張性のある設計
- PIDの特別扱いを美しく抽象化

### 技術詳細
**新しい設計：**
- **SystemVariable**: PIDなどシステム専用変数（警告なし）
- **ConditionalVariable**: GITHUB_TOKEN、SLACK_WEBHOOK_URLなど設定に基づく条件付き警告
- **UserVariable**: その他のユーザ定義変数（常に警告）

**実装アーキテクチャ：**
- Strategyパターンによる環境変数分類
- インターフェースベースの設計で将来の拡張に対応
- 責任の明確な分離と単体テスト可能な構造

### テスト結果
- 単体テスト: ✅ パス (全48テスト)
- 全体テスト: ✅ パス (全127テスト)

### 確認事項
- [x] 実装計画に沿った実装
- [x] 既存機能の完全な互換性維持
- [x] PID、GITHUB_TOKEN、SLACK_WEBHOOK_URLの動作確認
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] 美しく拡張可能な設計