### PR TITLE
feat: soba log コマンドの実装 (#84)

### DIFF
--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newLogCmd() *cobra.Command {
+	var lines int
+	var follow bool
+
+	cmd := &cobra.Command{
+		Use:   "log",
+		Short: "Display logs from the running soba process",
+		Long: `Display logs from the running soba process by reading from the log file
+associated with the currently running daemon process.
+
+The command reads the PID from .soba/soba.pid and displays the corresponding
+log file .soba/logs/soba-{pid}.log.
+
+Options:
+- Default: Show last 30 lines (equivalent to tail -n 30)
+- -n, --lines: Specify number of lines to show
+- -f, --follow: Follow log output in real-time (equivalent to tail -f)`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLog(cmd, lines, follow)
+		},
+	}
+
+	cmd.Flags().IntVarP(&lines, "lines", "n", 30, "number of lines to display")
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "follow log output")
+
+	return cmd
+}
+
+func runLog(cmd *cobra.Command, lines int, follow bool) error {
+	// Read PID from .soba/soba.pid
+	pidPath := filepath.Join(".soba", "soba.pid")
+	pidBytes, err := os.ReadFile(pidPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("PID file not found at %s. Is soba daemon running?", pidPath)
+		}
+		return fmt.Errorf("failed to read PID file: %w", err)
+	}
+
+	// Parse PID
+	pidStr := strings.TrimSpace(string(pidBytes))
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return fmt.Errorf("invalid PID in file %s: %s", pidPath, pidStr)
+	}
+
+	// Construct log file path
+	logPath := filepath.Join(".soba", "logs", fmt.Sprintf("soba-%d.log", pid))
+
+	// Check if log file exists
+	if _, err := os.Stat(logPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("log file not found at %s", logPath)
+		}
+		return fmt.Errorf("failed to access log file: %w", err)
+	}
+
+	if follow {
+		return followLog(cmd, logPath)
+	}
+
+	return tailLog(cmd, logPath, lines)
+}
+
+func tailLog(cmd *cobra.Command, logPath string, lines int) error {
+	file, err := os.Open(logPath)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %w", err)
+	}
+	defer file.Close()
+
+	// Read all lines into memory
+	allLines := make([]string, 0, 1000) // Pre-allocate with reasonable capacity
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		allLines = append(allLines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read log file: %w", err)
+	}
+
+	// Get last N lines
+	start := 0
+	if len(allLines) > lines {
+		start = len(allLines) - lines
+	}
+
+	// Output the lines
+	for i := start; i < len(allLines); i++ {
+		fmt.Fprintln(cmd.OutOrStdout(), allLines[i])
+	}
+
+	return nil
+}
+
+func followLog(cmd *cobra.Command, logPath string) error {
+	file, err := os.Open(logPath)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %w", err)
+	}
+	defer file.Close()
+
+	// First, output existing content
+	if err := tailLog(cmd, logPath, 30); err != nil {
+		return err
+	}
+
+	// Seek to end of file
+	if _, err := file.Seek(0, io.SeekEnd); err != nil {
+		return fmt.Errorf("failed to seek to end of file: %w", err)
+	}
+
+	// Follow new content
+	scanner := bufio.NewScanner(file)
+	for {
+		if scanner.Scan() {
+			fmt.Fprintln(cmd.OutOrStdout(), scanner.Text())
+		} else {
+			// No new content, wait a bit
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		// Check for errors
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("error reading log file: %w", err)
+		}
+	}
+}

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLogCmd(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "log command exists",
+			args: []string{"--help"},
+			want: "Display logs from the running soba process",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newLogCmd()
+			require.NotNil(t, cmd)
+
+			// Set up buffer to capture output
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			assert.NoError(t, err)
+
+			output := buf.String()
+			assert.Contains(t, output, tt.want)
+		})
+	}
+}
+
+func TestLogCommand_BasicAttributes(t *testing.T) {
+	cmd := newLogCmd()
+
+	assert.Equal(t, "log", cmd.Use)
+	assert.Equal(t, "Display logs from the running soba process", cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+}
+
+func TestLogCommand_Flags(t *testing.T) {
+	cmd := newLogCmd()
+
+	// Test lines flag
+	linesFlag := cmd.Flags().Lookup("lines")
+	require.NotNil(t, linesFlag)
+	assert.Equal(t, "n", linesFlag.Shorthand)
+	assert.Equal(t, "30", linesFlag.DefValue)
+
+	// Test follow flag
+	followFlag := cmd.Flags().Lookup("follow")
+	require.NotNil(t, followFlag)
+	assert.Equal(t, "f", followFlag.Shorthand)
+	assert.Equal(t, "false", followFlag.DefValue)
+}
+
+func TestRunLog_WithDefaultOptions(t *testing.T) {
+	// Create temporary directory structure
+	tempDir := t.TempDir()
+	sobaDir := filepath.Join(tempDir, ".soba")
+	logsDir := filepath.Join(sobaDir, "logs")
+	err := os.MkdirAll(logsDir, 0755)
+	require.NoError(t, err)
+
+	// Create PID file
+	pidFile := filepath.Join(sobaDir, "soba.pid")
+	err = os.WriteFile(pidFile, []byte("12345"), 0644)
+	require.NoError(t, err)
+
+	// Create log file with test content
+	logFile := filepath.Join(logsDir, "soba-12345.log")
+	logContent := ""
+	for i := 1; i <= 50; i++ {
+		logContent += "log line " + string(rune(i+'0'-1)) + "\n"
+	}
+	err = os.WriteFile(logFile, []byte(logContent), 0644)
+	require.NoError(t, err)
+
+	// Change to temp directory
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalDir)
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	// Test command
+	cmd := newLogCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.Execute()
+	assert.NoError(t, err)
+
+	output := buf.String()
+	// Should show last 30 lines by default
+	lines := bytes.Count([]byte(output), []byte("\n"))
+	assert.Equal(t, 30, lines)
+}
+
+func TestRunLog_WithLinesOption(t *testing.T) {
+	// Create temporary directory structure
+	tempDir := t.TempDir()
+	sobaDir := filepath.Join(tempDir, ".soba")
+	logsDir := filepath.Join(sobaDir, "logs")
+	err := os.MkdirAll(logsDir, 0755)
+	require.NoError(t, err)
+
+	// Create PID file
+	pidFile := filepath.Join(sobaDir, "soba.pid")
+	err = os.WriteFile(pidFile, []byte("12345"), 0644)
+	require.NoError(t, err)
+
+	// Create log file with test content
+	logFile := filepath.Join(logsDir, "soba-12345.log")
+	logContent := ""
+	for i := 1; i <= 50; i++ {
+		logContent += "log line " + string(rune(i+'0'-1)) + "\n"
+	}
+	err = os.WriteFile(logFile, []byte(logContent), 0644)
+	require.NoError(t, err)
+
+	// Change to temp directory
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalDir)
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	// Test command with -n 10
+	cmd := newLogCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"-n", "10"})
+
+	err = cmd.Execute()
+	assert.NoError(t, err)
+
+	output := buf.String()
+	// Should show last 10 lines
+	lines := bytes.Count([]byte(output), []byte("\n"))
+	assert.Equal(t, 10, lines)
+}
+
+func TestRunLog_NoPidFile(t *testing.T) {
+	// Create temporary directory without PID file
+	tempDir := t.TempDir()
+
+	// Change to temp directory
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalDir)
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	// Test command
+	cmd := newLogCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "PID file not found")
+}
+
+func TestRunLog_NoLogFile(t *testing.T) {
+	// Create temporary directory structure
+	tempDir := t.TempDir()
+	sobaDir := filepath.Join(tempDir, ".soba")
+	err := os.MkdirAll(sobaDir, 0755)
+	require.NoError(t, err)
+
+	// Create PID file
+	pidFile := filepath.Join(sobaDir, "soba.pid")
+	err = os.WriteFile(pidFile, []byte("12345"), 0644)
+	require.NoError(t, err)
+
+	// Change to temp directory (no log file)
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalDir)
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	// Test command
+	cmd := newLogCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "log file not found")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,6 +36,7 @@ development workflows through seamless integration with Claude Code AI.`,
 	cmd.AddCommand(newStatusCmd())
 	cmd.AddCommand(newStopCmd())
 	cmd.AddCommand(newOpenCmd())
+	cmd.AddCommand(newLogCmd())
 
 	return cmd
 }


### PR DESCRIPTION
# 実装完了

fixes #84

## 変更内容
- soba logコマンドの新規実装
  - `.soba/soba.pid`からプロセスIDを読み取り、対応するログファイル`.soba/logs/soba-{pid}.log`を表示
  - `-n/--lines`オプションで表示行数指定（デフォルト30行）
  - `-f/--follow`オプションでリアルタイム監視機能
  - PIDファイルやログファイルが存在しない場合の適切なエラーハンドリング
- rootコマンドへのlogコマンド登録

## テスト結果
- 単体テスト: ✅ パス（TestNewLogCmd、TestLogCommand系、TestRunLog系すべて）
- 全体テスト: ✅ パス（既存テストへの影響なし）

## 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] TDDアプローチでのRed-Green-Refactorサイクル実践
- [x] Cobraフレームワークに準拠したCLI実装