### PR TITLE
feat: Slack通知でlogging.Loggerを使用するように移行

### DIFF
--- a/internal/infra/slack/notifier_test.go
+++ b/internal/infra/slack/notifier_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/douhashi/soba/internal/config"
+	"github.com/douhashi/soba/pkg/logging"
 )
 
 type mockSlackClient struct {
@@ -94,7 +95,8 @@ func TestNotifier_NotifyPhaseStart(t *testing.T) {
 				NotificationsEnabled: tt.enabled,
 			}
 
-			notifier := NewSyncNotifier(mockClient, config)
+			logger := logging.NewMockLogger()
+			notifier := NewSyncNotifier(mockClient, config, logger)
 			err := notifier.NotifyPhaseStart(tt.phase, tt.issueNumber)
 
 			if tt.wantError && err == nil {
@@ -168,7 +170,8 @@ func TestNotifier_NotifyPRMerged(t *testing.T) {
 				NotificationsEnabled: tt.enabled,
 			}
 
-			notifier := NewSyncNotifier(mockClient, config)
+			logger := logging.NewMockLogger()
+			notifier := NewSyncNotifier(mockClient, config, logger)
 			err := notifier.NotifyPRMerged(tt.prNumber, tt.issueNumber)
 
 			if tt.wantError && err == nil {
@@ -201,7 +204,8 @@ func TestNotifier_AsyncNotify(t *testing.T) {
 		NotificationsEnabled: true,
 	}
 
-	notifier := NewNotifier(mockClient, config)
+	logger := logging.NewMockLogger()
+	notifier := NewNotifier(mockClient, config, logger)
 
 	// 非同期通知をテスト
 	wg.Add(1) // 1つのメッセージを待機
@@ -228,7 +232,8 @@ func TestNewNotifier(t *testing.T) {
 		NotificationsEnabled: true,
 	}
 
-	notifier := NewNotifier(mockClient, config)
+	logger := logging.NewMockLogger()
+	notifier := NewNotifier(mockClient, config, logger)
 
 	if notifier == nil {
 		t.Error("Expected notifier to be created, got nil")

--- a/internal/service/builder/dependency_resolver.go
+++ b/internal/service/builder/dependency_resolver.go
@@ -94,7 +94,8 @@ func (r *DependencyResolver) ResolveClients(ctx context.Context) (*ResolvedClien
 	if r.config.Slack.NotificationsEnabled && r.config.Slack.WebhookURL != "" {
 		r.logger.Info(ctx, "Initializing Slack client for notifications")
 		slackClient := slack.NewClient(r.config.Slack.WebhookURL, 10*time.Second)
-		clients.SlackNotifier = slack.NewNotifier(slackClient, &r.config.Slack)
+		slackLogger := r.logFactory.CreateComponentLogger("slack-notifier")
+		clients.SlackNotifier = slack.NewNotifier(slackClient, &r.config.Slack, slackLogger)
 	} else {
 		r.logger.Debug(ctx, "Slack notifications not configured")
 	}


### PR DESCRIPTION
## Summary
- Slack通知のログ出力を`log.Printf`から`logging.Logger`に移行
- ログレベル設定により通知の送信状況を適切に記録できるように改善
- `--log-level debug`オプションで詳細なSlack通知ログを確認可能

## 変更内容
- `internal/infra/slack/notifier.go`: logging.Loggerを使用するよう更新
- `internal/service/builder/dependency_resolver.go`: Slack用のコンポーネントロガーを追加
- テストファイルをMockLoggerを使用するよう更新

## Test plan
- [x] ビルド成功を確認
- [x] 全テストがパスすることを確認
- [x] Slack Webhook接続テストを実施
- [ ] `--log-level debug`でSlack通知の詳細ログが出力されることを確認
- [ ] `--log-level warn`でエラーのみログ出力されることを確認

## 関連Issue
Slack通知が行われない問題の調査から、ログレベル設定の影響でログが出力されていないことが判明したため改善

🤖 Generated with [Claude Code](https://claude.ai/code)