### PR TITLE
fix: ログレベル設定の優先順位を修正し、CLIフラグが正しく反映されるように改善 (#105)

### DIFF
--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -33,7 +33,12 @@ Use -v/--verbose flag to enable debug logging.`,
 }
 
 func runStart(cmd *cobra.Command, args []string, daemon bool) error {
-	daemonService := service.NewDaemonService(GetLogFactory())
+	// Get CLI log level and verbose flags from root command
+	root := cmd.Root()
+	cliLogLevel, _ := root.Flags().GetString("log-level")
+	verboseFlag, _ := root.Flags().GetBool("verbose")
+
+	daemonService := service.NewDaemonServiceWithCLIParams(GetLogFactory(), cliLogLevel, verboseFlag)
 	return runStartWithService(cmd, args, daemon, daemonService)
 }
 

--- a/internal/service/builder/service_builder.go
+++ b/internal/service/builder/service_builder.go
@@ -17,6 +17,8 @@ type ServiceBuilder struct {
 	errorHandler ErrorHandler
 	resolver     *DependencyResolver
 	clients      *Clients
+	cliLogLevel  string // CLI log level flag
+	verbose      bool   // CLI verbose flag
 }
 
 // NewServiceBuilder creates a new service builder with new logging system
@@ -45,6 +47,18 @@ func (b *ServiceBuilder) WithWorkDir(workDir string) *ServiceBuilder {
 // WithErrorHandler sets error handling strategy
 func (b *ServiceBuilder) WithErrorHandler(handler ErrorHandler) *ServiceBuilder {
 	b.errorHandler = handler
+	return b
+}
+
+// WithCLILogLevel sets CLI log level
+func (b *ServiceBuilder) WithCLILogLevel(level string) *ServiceBuilder {
+	b.cliLogLevel = level
+	return b
+}
+
+// WithVerbose sets verbose flag
+func (b *ServiceBuilder) WithVerbose(verbose bool) *ServiceBuilder {
+	b.verbose = verbose
 	return b
 }
 

--- a/internal/service/log_level_test.go
+++ b/internal/service/log_level_test.go
@@ -1,0 +1,164 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/douhashi/soba/internal/config"
+	"github.com/douhashi/soba/pkg/logging"
+)
+
+func TestLogLevelPriority(t *testing.T) {
+	tests := []struct {
+		name           string
+		cliLogLevel    string
+		configLogLevel string
+		envLogLevel    string
+		verbose        bool
+		expectedLevel  string
+	}{
+		{
+			name:           "CLI flag takes highest priority",
+			cliLogLevel:    "debug",
+			configLogLevel: "info",
+			envLogLevel:    "warn",
+			verbose:        false,
+			expectedLevel:  "debug",
+		},
+		{
+			name:           "Verbose flag used when no CLI log level",
+			cliLogLevel:    "",
+			configLogLevel: "info",
+			envLogLevel:    "warn",
+			verbose:        true,
+			expectedLevel:  "debug",
+		},
+		{
+			name:           "Config file used when no CLI flags",
+			cliLogLevel:    "",
+			configLogLevel: "info",
+			envLogLevel:    "warn",
+			verbose:        false,
+			expectedLevel:  "info",
+		},
+		{
+			name:           "Environment variable used when no config",
+			cliLogLevel:    "",
+			configLogLevel: "",
+			envLogLevel:    "error",
+			verbose:        false,
+			expectedLevel:  "error",
+		},
+		{
+			name:           "Default to warn when nothing specified",
+			cliLogLevel:    "",
+			configLogLevel: "",
+			envLogLevel:    "",
+			verbose:        false,
+			expectedLevel:  "warn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			// Set environment variable
+			if tt.envLogLevel != "" {
+				t.Setenv("LOG_LEVEL", tt.envLogLevel)
+			}
+
+			// Create daemon service with mock dependencies
+			logFactory, err := logging.NewFactory(logging.Config{
+				Level:  tt.expectedLevel,
+				Format: "text",
+			})
+			require.NoError(t, err)
+
+			service := &daemonService{
+				workDir: tmpDir,
+				logger:  logFactory.CreateComponentLogger("test"),
+			}
+
+			// Test initializeLogging with config
+			cfg := &config.Config{
+				Log: config.LogConfig{
+					Level:      tt.configLogLevel,
+					OutputPath: filepath.Join(tmpDir, "test.log"),
+				},
+			}
+
+			// Initialize logging
+			_, err = service.initializeLoggingWithCLILevel(cfg, false, tt.cliLogLevel, tt.verbose)
+			assert.NoError(t, err)
+
+			// Verify the effective log level
+			effectiveLevel := service.getEffectiveLogLevel(cfg, tt.cliLogLevel, tt.verbose)
+			assert.Equal(t, tt.expectedLevel, effectiveLevel)
+		})
+	}
+}
+
+func TestDaemonModeLogLevelPropagation(t *testing.T) {
+	tmpDir := t.TempDir()
+	sobaDir := filepath.Join(tmpDir, ".soba")
+	require.NoError(t, os.MkdirAll(sobaDir, 0755))
+
+	tests := []struct {
+		name        string
+		cliLogLevel string
+		verbose     bool
+		expectedLog string
+	}{
+		{
+			name:        "CLI log level propagated to daemon",
+			cliLogLevel: "debug",
+			verbose:     false,
+			expectedLog: "debug",
+		},
+		{
+			name:        "Verbose flag propagated to daemon",
+			cliLogLevel: "",
+			verbose:     true,
+			expectedLog: "debug",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create log factory with expected level
+			logFactory, err := logging.NewFactory(logging.Config{
+				Level:  tt.expectedLog,
+				Format: "text",
+			})
+			require.NoError(t, err)
+
+			// Create service with CLI level
+			service := &daemonService{
+				workDir:     tmpDir,
+				logger:      logFactory.CreateComponentLogger("test"),
+				cliLogLevel: tt.cliLogLevel,
+				verbose:     tt.verbose,
+			}
+
+			cfg := &config.Config{
+				Log: config.LogConfig{
+					OutputPath: filepath.Join(tmpDir, "daemon.log"),
+				},
+			}
+
+			// Test that daemon mode uses CLI level
+			ctx := context.Background()
+			effectiveLevel := service.getEffectiveLogLevel(cfg, tt.cliLogLevel, tt.verbose)
+			service.logger.Debug(ctx, "Testing log level",
+				logging.Field{Key: "effective", Value: effectiveLevel})
+
+			assert.Equal(t, tt.expectedLog, effectiveLevel)
+		})
+	}
+}


### PR DESCRIPTION
## 実装完了

fixes #105

### 変更内容
- daemon/foregroundモード起動時にCLIフラグ（`--log-level`, `--verbose`）のログレベルを正しくサービス層へ伝搬
- ログレベルの優先順位を以下のように明確化:
  1. `--log-level` フラグ（最優先）
  2. `--verbose` フラグ（debugレベル）
  3. `config.yml` のlog.level設定
  4. `LOG_LEVEL` 環境変数
  5. デフォルト値（warn）
- `NewDaemonServiceWithCLIParams`を追加し、CLIパラメータを受け取れるように改善
- ServiceBuilderに`WithCLILogLevel`と`WithVerbose`メソッドを追加

### テスト結果
- 単体テスト: ✅ パス（新規作成したログレベル優先順位テストを含む）
- 全体テスト: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保（優先順位テスト、伝搬テストを追加）
- [x] 既存機能への影響なし
- [x] CLIフラグが設定ファイルや環境変数より優先されることを確認

### 動作確認方法
```bash
# デフォルト（warnレベル）
soba start

# --log-level フラグ指定（最優先）
soba start --log-level debug

# --verbose フラグ（debugレベル）
soba start --verbose

# daemonモードでも同様に動作
soba start -d --log-level info
```