### PR TITLE
feat: implement Config and Logger singleton with app package

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -2,14 +2,12 @@
 package cli
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/douhashi/soba/internal/config"
-	"github.com/douhashi/soba/pkg/logging"
+	"github.com/douhashi/soba/pkg/app"
 )
 
 // newConfigCmd creates a new config command
@@ -32,22 +30,9 @@ Sensitive information like tokens and webhook URLs will be masked.`,
 }
 
 // runConfig executes the config command
-func runConfig(cmd *cobra.Command, configPath string) error {
-	log := logging.NewMockLogger()
-
-	// 設定ファイルパスを決定
-	if configPath == "" {
-		configPath = filepath.Join(".soba", "config.yml")
-	}
-
-	log.Debug(context.Background(), "Loading config file", logging.Field{Key: "path", Value: configPath})
-
-	// 設定ファイルを読み込み
-	cfg, err := config.Load(configPath)
-	if err != nil {
-		cmd.PrintErrf("Error: Failed to load config file: %v\n", err)
-		return err
-	}
+func runConfig(cmd *cobra.Command, _ string) error {
+	// Get config from global app
+	cfg := app.Config()
 
 	// 設定内容を表示用に整形
 	output, err := config.DisplayConfig(cfg)

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -21,7 +21,11 @@ func newInitCmd() *cobra.Command {
 		Use:   "init",
 		Short: "Initialize soba configuration",
 		Long:  `Initialize soba configuration by creating a .soba/config.yml file in the current directory`,
-		RunE:  runInit,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Skip parent's PersistentPreRunE
+			return nil
+		},
+		RunE: runInit,
 	}
 
 	return cmd

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-
-	"github.com/spf13/cobra"
 )
 
 func TestExecute(t *testing.T) {
@@ -180,7 +178,6 @@ func TestLogLevelFlag(t *testing.T) {
 			rootCmd = newRootCmd()
 			logLevel = ""
 			verbose = false
-			cobra.OnInitialize(initConfig)
 			rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file path")
 			rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 			rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "set log level (debug, info, warn, error)")
@@ -233,7 +230,6 @@ func TestLogLevelPriority(t *testing.T) {
 			rootCmd = newRootCmd()
 			logLevel = ""
 			verbose = false
-			cobra.OnInitialize(initConfig)
 			rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file path")
 			rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 			rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "set log level (debug, info, warn, error)")

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/douhashi/soba/internal/service"
 	"github.com/douhashi/soba/internal/service/builder"
-	"github.com/douhashi/soba/pkg/logging"
+	"github.com/douhashi/soba/pkg/app"
 )
 
 func newStatusCmd() *cobra.Command {
@@ -27,11 +27,11 @@ func newStatusCmd() *cobra.Command {
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {
-	log := logging.NewMockLogger()
+	log := app.LogFactory().CreateComponentLogger("cli")
 	log.Debug(context.Background(), "Running status command")
 
 	// Get the global log factory
-	logFactory := GetLogFactory()
+	logFactory := app.LogFactory()
 
 	// Create service builder
 	sb := builder.NewServiceBuilder(logFactory)

--- a/internal/cli/stop_test.go
+++ b/internal/cli/stop_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/douhashi/soba/pkg/app"
 )
 
 // MockStopService はStopServiceのモック実装
@@ -20,6 +22,10 @@ func (m *MockStopService) Stop(ctx context.Context, repository string) error {
 }
 
 func TestStopCommand(t *testing.T) {
+	// Initialize app for testing
+	helper := app.NewTestHelper(t)
+	helper.InitializeForTest()
+
 	tests := []struct {
 		name           string
 		args           []string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,7 @@ type LogConfig struct {
 	OutputPath     string `yaml:"output_path"`
 	RetentionCount int    `yaml:"retention_count"`
 	Level          string `yaml:"level"`
+	Format         string `yaml:"format"` // "json" or "text"
 }
 
 func Load(path string) (*Config, error) {
@@ -141,5 +142,8 @@ func (c *Config) setDefaults() {
 	}
 	if c.Log.RetentionCount == 0 {
 		c.Log.RetentionCount = 10
+	}
+	if c.Log.Format == "" {
+		c.Log.Format = "text" // Default to text format
 	}
 }

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -70,6 +70,8 @@ log:
   retention_count: 10
   # Log level: debug, info, warn, error (default: warn)
   level: warn
+  # Log format: "text" or "json" (default: text)
+  format: text
 
 # Phase commands (optional - for custom Claude commands)
 phase:

--- a/internal/infra/github/client_test.go
+++ b/internal/infra/github/client_test.go
@@ -10,10 +10,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/douhashi/soba/pkg/logging"
 )
 
 func TestClient(t *testing.T) {
 	ctx := context.Background()
+	mockLogger := logging.NewMockLogger()
 
 	t.Run("NewClient", func(t *testing.T) {
 		t.Run("creates client with token provider", func(t *testing.T) {
@@ -21,7 +24,9 @@ func TestClient(t *testing.T) {
 				token: "test-token",
 			}
 
-			client, err := NewClient(tokenProvider, nil)
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				Logger: mockLogger,
+			})
 			require.NoError(t, err)
 			assert.NotNil(t, client)
 			assert.Equal(t, tokenProvider, client.tokenProvider)
@@ -36,6 +41,7 @@ func TestClient(t *testing.T) {
 			opts := &ClientOptions{
 				BaseURL: "https://github.enterprise.com/api/v3",
 				Timeout: 30 * time.Second,
+				Logger:  mockLogger,
 			}
 
 			client, err := NewClient(tokenProvider, opts)
@@ -79,6 +85,7 @@ func TestClient(t *testing.T) {
 
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  mockLogger,
 			})
 			require.NoError(t, err)
 
@@ -107,6 +114,7 @@ func TestClient(t *testing.T) {
 
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  mockLogger,
 			})
 			require.NoError(t, err)
 
@@ -126,7 +134,9 @@ func TestClient(t *testing.T) {
 				err:   assert.AnError,
 			}
 
-			client, err := NewClient(tokenProvider, nil)
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				Logger: mockLogger,
+			})
 			require.NoError(t, err)
 
 			req, err := http.NewRequestWithContext(ctx, "GET", defaultBaseURL+"/repos/test/repo/issues", nil)
@@ -155,6 +165,7 @@ func TestClient(t *testing.T) {
 
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  mockLogger,
 			})
 			require.NoError(t, err)
 
@@ -189,6 +200,7 @@ func TestClient(t *testing.T) {
 
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  mockLogger,
 			})
 			require.NoError(t, err)
 

--- a/internal/infra/github/integration_test.go
+++ b/internal/infra/github/integration_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/douhashi/soba/pkg/logging"
 )
 
 func TestIntegration(t *testing.T) {
@@ -27,7 +29,10 @@ func TestIntegration(t *testing.T) {
 			tokenProvider := NewEnvTokenProvider("GITHUB_TOKEN")
 
 			// クライアントを作成
-			client, err := NewClient(tokenProvider, nil)
+			mockLogger := logging.NewMockLogger()
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				Logger: mockLogger,
+			})
 			require.NoError(t, err)
 
 			// GitHub公開リポジトリから Issue を取得
@@ -111,8 +116,10 @@ func TestEndToEnd(t *testing.T) {
 		}
 
 		// クライアントの作成
+		mockLogger := logging.NewMockLogger()
 		client, err := NewClient(tokenProvider, &ClientOptions{
 			BaseURL: server.URL,
+			Logger:  mockLogger,
 		})
 		require.NoError(t, err)
 
@@ -170,6 +177,7 @@ func TestEndToEnd(t *testing.T) {
 		// リトライ機能付きクライアントの作成
 		client, err := NewClient(tokenProvider, &ClientOptions{
 			BaseURL: server.URL,
+			Logger:  logging.NewMockLogger(),
 		})
 		require.NoError(t, err)
 
@@ -178,6 +186,7 @@ func TestEndToEnd(t *testing.T) {
 			MaxRetries:  3,
 			InitialWait: 10 * time.Millisecond,
 			MaxWait:     100 * time.Millisecond,
+			Logger:      logging.NewMockLogger(),
 		})
 
 		var issues []Issue
@@ -232,6 +241,7 @@ func TestEndToEnd(t *testing.T) {
 
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  logging.NewMockLogger(),
 			})
 			require.NoError(t, err)
 
@@ -248,6 +258,7 @@ func TestEndToEnd(t *testing.T) {
 
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  logging.NewMockLogger(),
 			})
 			require.NoError(t, err)
 

--- a/internal/infra/github/issue_test.go
+++ b/internal/infra/github/issue_test.go
@@ -11,10 +11,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/douhashi/soba/pkg/logging"
 )
 
 func TestIssue(t *testing.T) {
 	ctx := context.Background()
+	mockLogger := logging.NewMockLogger()
 
 	t.Run("ListOpenIssues", func(t *testing.T) {
 		t.Run("returns list of open issues", func(t *testing.T) {
@@ -50,6 +53,7 @@ func TestIssue(t *testing.T) {
 			tokenProvider := &mockTokenProvider{token: "test-token"}
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  mockLogger,
 			})
 			require.NoError(t, err)
 
@@ -80,6 +84,7 @@ func TestIssue(t *testing.T) {
 			tokenProvider := &mockTokenProvider{token: "test-token"}
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  mockLogger,
 			})
 			require.NoError(t, err)
 
@@ -106,6 +111,7 @@ func TestIssue(t *testing.T) {
 			tokenProvider := &mockTokenProvider{token: "test-token"}
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  mockLogger,
 			})
 			require.NoError(t, err)
 
@@ -127,6 +133,7 @@ func TestIssue(t *testing.T) {
 			tokenProvider := &mockTokenProvider{token: "test-token"}
 			client, err := NewClient(tokenProvider, &ClientOptions{
 				BaseURL: server.URL,
+				Logger:  mockLogger,
 			})
 			require.NoError(t, err)
 
@@ -138,7 +145,9 @@ func TestIssue(t *testing.T) {
 
 		t.Run("validates required parameters", func(t *testing.T) {
 			tokenProvider := &mockTokenProvider{token: "test-token"}
-			client, err := NewClient(tokenProvider, nil)
+			client, err := NewClient(tokenProvider, &ClientOptions{
+				Logger: mockLogger,
+			})
 			require.NoError(t, err)
 
 			// オーナーが空の場合
@@ -175,7 +184,9 @@ func TestIssue(t *testing.T) {
 	})
 
 	t.Run("buildIssuesURL", func(t *testing.T) {
-		client, err := NewClient(&mockTokenProvider{token: "test"}, nil)
+		client, err := NewClient(&mockTokenProvider{token: "test"}, &ClientOptions{
+			Logger: mockLogger,
+		})
 		require.NoError(t, err)
 
 		t.Run("builds basic URL", func(t *testing.T) {

--- a/internal/infra/github/retry.go
+++ b/internal/infra/github/retry.go
@@ -37,8 +37,8 @@ type RetryableClient struct {
 
 // NewRetryableClient は新しいRetryableClientを作成する
 func NewRetryableClient(opts *RetryOptions) *RetryableClient {
-	if opts == nil {
-		opts = defaultRetryOptions
+	if opts == nil || opts.Logger == nil {
+		panic("RetryOptions with Logger is required")
 	}
 
 	if opts.Multiplier == 0 {
@@ -51,16 +51,9 @@ func NewRetryableClient(opts *RetryOptions) *RetryableClient {
 		opts.MaxWait = 30 * time.Second
 	}
 
-	l := opts.Logger
-	if l == nil {
-		// デフォルトロガーの作成
-		factory, _ := logging.NewFactory(logging.Config{})
-		l = factory.CreateComponentLogger("github-retry")
-	}
-
 	return &RetryableClient{
 		options: opts,
-		logger:  l,
+		logger:  opts.Logger,
 	}
 }
 

--- a/internal/infra/github/retry_test.go
+++ b/internal/infra/github/retry_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/douhashi/soba/pkg/logging"
 )
 
 func TestRetry(t *testing.T) {
@@ -24,7 +26,9 @@ func TestRetry(t *testing.T) {
 				}, nil
 			}
 
-			retrier := NewRetryableClient(nil)
+			retrier := NewRetryableClient(&RetryOptions{
+				Logger: logging.NewMockLogger(),
+			})
 			resp, err := retrier.DoWithRetry(ctx, handler)
 			require.NoError(t, err)
 			assert.NotNil(t, resp)
@@ -50,6 +54,7 @@ func TestRetry(t *testing.T) {
 				MaxRetries:  3,
 				InitialWait: 10 * time.Millisecond,
 				MaxWait:     100 * time.Millisecond,
+				Logger:      logging.NewMockLogger(),
 			}
 			retrier := NewRetryableClient(opts)
 			resp, err := retrier.DoWithRetry(ctx, handler)
@@ -76,6 +81,7 @@ func TestRetry(t *testing.T) {
 			opts := &RetryOptions{
 				MaxRetries:  3,
 				InitialWait: 10 * time.Millisecond,
+				Logger:      logging.NewMockLogger(),
 			}
 			retrier := NewRetryableClient(opts)
 			resp, err := retrier.DoWithRetry(ctx, handler)
@@ -100,6 +106,7 @@ func TestRetry(t *testing.T) {
 			opts := &RetryOptions{
 				MaxRetries:  3,
 				InitialWait: 10 * time.Millisecond,
+				Logger:      logging.NewMockLogger(),
 			}
 			retrier := NewRetryableClient(opts)
 			resp, err := retrier.DoWithRetry(ctx, handler)
@@ -120,6 +127,7 @@ func TestRetry(t *testing.T) {
 			opts := &RetryOptions{
 				MaxRetries:  2,
 				InitialWait: 10 * time.Millisecond,
+				Logger:      logging.NewMockLogger(),
 			}
 			retrier := NewRetryableClient(opts)
 			resp, err := retrier.DoWithRetry(ctx, handler)
@@ -138,7 +146,9 @@ func TestRetry(t *testing.T) {
 				}, nil
 			}
 
-			retrier := NewRetryableClient(nil)
+			retrier := NewRetryableClient(&RetryOptions{
+				Logger: logging.NewMockLogger(),
+			})
 			resp, err := retrier.DoWithRetry(ctx, handler)
 			require.NoError(t, err)
 			assert.NotNil(t, resp)
@@ -158,7 +168,9 @@ func TestRetry(t *testing.T) {
 				}, nil
 			}
 
-			retrier := NewRetryableClient(nil)
+			retrier := NewRetryableClient(&RetryOptions{
+				Logger: logging.NewMockLogger(),
+			})
 			resp, err := retrier.DoWithRetry(cancelCtx, handler)
 			assert.Error(t, err)
 			assert.Nil(t, resp)
@@ -203,6 +215,7 @@ func TestRetry(t *testing.T) {
 			InitialWait: 100 * time.Millisecond,
 			MaxWait:     2 * time.Second,
 			Multiplier:  2,
+			Logger:      logging.NewMockLogger(),
 		}
 
 		t.Run("exponential backoff", func(t *testing.T) {

--- a/internal/service/builder/dependency_resolver.go
+++ b/internal/service/builder/dependency_resolver.go
@@ -43,7 +43,9 @@ func (r *DependencyResolver) ResolveClients(ctx context.Context) (*ResolvedClien
 	// GitHub Client (必須)
 	r.logger.Debug(ctx, "Initializing GitHub client")
 	tokenProvider := github.NewDefaultTokenProvider()
-	githubClientImpl, err := github.NewClient(tokenProvider, &github.ClientOptions{})
+	githubClientImpl, err := github.NewClient(tokenProvider, &github.ClientOptions{
+		Logger: r.logFactory.CreateComponentLogger("github-client"),
+	})
 	if err != nil {
 		r.logger.Error(ctx, "Failed to initialize GitHub client",
 			logging.Field{Key: "error", Value: err.Error()},

--- a/internal/service/daemon_test.go
+++ b/internal/service/daemon_test.go
@@ -13,11 +13,17 @@ import (
 
 	"github.com/douhashi/soba/internal/config"
 	"github.com/douhashi/soba/internal/infra/github"
+	"github.com/douhashi/soba/pkg/app"
 	"github.com/douhashi/soba/pkg/logging"
 )
 
 func TestNewDaemonService(t *testing.T) {
-	service := NewDaemonService(nil)
+	// Initialize app for testing
+	helper := app.NewTestHelper(t)
+	helper.InitializeForTest()
+
+	// Create service with global LogFactory
+	service := NewDaemonService(app.LogFactory())
 	assert.NotNil(t, service)
 }
 
@@ -553,7 +559,7 @@ func TestDaemonService_InitializeLogging(t *testing.T) {
 				logger:  mockLogger,
 			}
 
-			logPath, err := service.initializeLogging(tt.cfg, false)
+			logPath, err := service.prepareLogPath(tt.cfg)
 
 			if tt.wantError {
 				assert.Error(t, err)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,0 +1,158 @@
+package app
+
+import (
+	"sync"
+
+	"github.com/douhashi/soba/internal/config"
+	"github.com/douhashi/soba/pkg/logging"
+)
+
+var (
+	cfg        *config.Config
+	logFactory *logging.Factory
+	mu         sync.RWMutex
+
+	initialized bool
+)
+
+// InitOptions holds initialization options
+type InitOptions struct {
+	LogLevel string
+	Verbose  bool
+}
+
+// MustInitialize initializes the application (panics on failure)
+func MustInitialize(configPath string) {
+	MustInitializeWithOptions(configPath, nil)
+}
+
+// MustInitializeWithOptions initializes the application with CLI options
+func MustInitializeWithOptions(configPath string, opts *InitOptions) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if initialized {
+		panic("app already initialized")
+	}
+
+	// Load config
+	var err error
+	cfg, err = config.Load(configPath)
+	if err != nil {
+		panic("failed to load config: " + err.Error())
+	}
+
+	// Determine effective log level (CLI > verbose > config > default)
+	logLevel := cfg.Log.Level
+	if opts != nil {
+		if opts.LogLevel != "" {
+			logLevel = opts.LogLevel
+		} else if opts.Verbose {
+			logLevel = "debug"
+		}
+	}
+	if logLevel == "" {
+		logLevel = "warn" // Default
+	}
+
+	// Create Logger Factory
+	logFactory, err = logging.NewFactory(logging.Config{
+		Level:        logLevel,
+		Format:       cfg.Log.Format,
+		Output:       cfg.Log.OutputPath,
+		AlsoToStdout: true,
+	})
+	if err != nil {
+		panic("failed to create logger factory: " + err.Error())
+	}
+
+	initialized = true
+}
+
+// MustInitializeForTest initializes the application for testing
+func MustInitializeForTest(testConfig *config.Config) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if initialized {
+		panic("app already initialized")
+	}
+
+	cfg = testConfig
+
+	// Create Logger Factory for test
+	var err error
+	logFactory, err = logging.NewFactory(logging.Config{
+		Level:        cfg.Log.Level,
+		Format:       cfg.Log.Format,
+		Output:       "stdout",
+		AlsoToStdout: false,
+	})
+	if err != nil {
+		panic("failed to create logger factory: " + err.Error())
+	}
+
+	initialized = true
+}
+
+// Config returns the global Config
+func Config() *config.Config {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	if !initialized {
+		panic("app not initialized")
+	}
+	return cfg
+}
+
+// LogFactory returns the global Logger Factory
+func LogFactory() *logging.Factory {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	if !initialized {
+		panic("app not initialized")
+	}
+	return logFactory
+}
+
+// UpdateLogLevel updates the log level at runtime
+func UpdateLogLevel(level string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if !initialized {
+		panic("app not initialized")
+	}
+
+	// Create new Factory with updated level
+	newFactory, err := logging.NewFactory(logging.Config{
+		Level:        level,
+		Format:       cfg.Log.Format,
+		Output:       cfg.Log.OutputPath,
+		AlsoToStdout: true,
+	})
+	if err != nil {
+		panic("failed to update logger: " + err.Error())
+	}
+
+	logFactory = newFactory
+}
+
+// Reset resets the application state (for testing)
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	cfg = nil
+	logFactory = nil
+	initialized = false
+}
+
+// IsInitialized returns whether the app is initialized
+func IsInitialized() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return initialized
+}

--- a/pkg/app/testing.go
+++ b/pkg/app/testing.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/douhashi/soba/internal/config"
+)
+
+// TestHelper provides test utilities
+type TestHelper struct {
+	t *testing.T
+}
+
+// NewTestHelper creates a test helper
+func NewTestHelper(t *testing.T) *TestHelper {
+	return &TestHelper{t: t}
+}
+
+// InitializeForTest initializes app for testing with default config
+func (h *TestHelper) InitializeForTest() {
+	h.InitializeForTestWithConfig(nil)
+}
+
+// InitializeForTestWithConfig initializes app for testing with custom config
+func (h *TestHelper) InitializeForTestWithConfig(testConfig *config.Config) {
+	// Reset any existing state
+	Reset()
+
+	// Use provided config or create default test config
+	if testConfig == nil {
+		testConfig = &config.Config{
+			GitHub: config.GitHubConfig{
+				Repository: "test/repo",
+			},
+			Log: config.LogConfig{
+				Level:      "debug",
+				OutputPath: "stdout",
+			},
+			Workflow: config.WorkflowConfig{
+				Interval: 300,
+			},
+		}
+	}
+
+	// Initialize app with test config
+	MustInitializeForTest(testConfig)
+
+	// Register cleanup
+	h.t.Cleanup(func() {
+		Reset()
+	})
+}
+
+// InitializeForTestWithOptions initializes app for testing with CLI options
+func (h *TestHelper) InitializeForTestWithOptions(configPath string, opts *InitOptions) {
+	// Reset any existing state
+	Reset()
+
+	// Initialize with options
+	MustInitializeWithOptions(configPath, opts)
+
+	// Register cleanup
+	h.t.Cleanup(func() {
+		Reset()
+	})
+}

--- a/pkg/logging/factory.go
+++ b/pkg/logging/factory.go
@@ -49,8 +49,13 @@ func NewFactory(cfg Config) (*Factory, error) {
 	}
 
 	level := parseLevel(cfg.Level)
+
+	// Create a LevelVar to properly set the minimum log level
+	levelVar := new(slog.LevelVar)
+	levelVar.Set(level)
+
 	opts := &slog.HandlerOptions{
-		Level:     level,
+		Level:     levelVar,
 		AddSource: cfg.AddSource,
 	}
 

--- a/pkg/logging/factory_test.go
+++ b/pkg/logging/factory_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,7 +69,11 @@ func TestFactory(t *testing.T) {
 
 		// Test that logging creates the file
 		logger := factory.CreateLogger()
-		logger.Info(context.Background(), "test message")
+		// Use Error level to ensure it's logged (since level is "warn")
+		logger.Error(context.Background(), "test message")
+
+		// Wait a moment for file to be created
+		time.Sleep(100 * time.Millisecond)
 
 		// File should be created
 		_, err = os.Stat(logFile)

--- a/pkg/logging/handler.go
+++ b/pkg/logging/handler.go
@@ -31,7 +31,8 @@ func NewPrettyTextHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
 
 // Enabled implements slog.Handler
 func (h *PrettyTextHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	minLevel := slog.LevelInfo
+	// Default to debug level if not specified
+	minLevel := slog.LevelDebug
 	if h.opts.Level != nil {
 		minLevel = h.opts.Level.Level()
 	}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -85,6 +85,11 @@ func (l *contextLogger) log(ctx context.Context, level slog.Level, msg string, f
 		ctx = context.Background()
 	}
 
+	// Check if this level is enabled before processing
+	if !l.handler.Enabled(ctx, level) {
+		return
+	}
+
 	// Extract context values
 	attrs := l.extractContextAttributes(ctx)
 


### PR DESCRIPTION
## Summary

- Add `pkg/app` package for centralized Config and LogFactory management using singleton pattern
- Implement thread-safe initialization with proper log level priority handling
- Integrate all logging components to use unified `app.LogFactory()` 
- Fix `soba init` command to work without existing config file
- Add comprehensive test coverage and ensure all tests pass

## Key Changes

### Core Infrastructure
- **New `pkg/app` package**: Centralized singleton management for Config and LogFactory with thread-safe initialization
- **Log level priority fix**: CLI flags > verbose flag > config file > default (warn)
- **Unified logger integration**: Remove direct zap dependencies in `closed_issue_cleanup.go`

### CLI Layer Improvements
- **`root.go`**: Add `PersistentPreRunE` to initialize app for all commands except `init` and `version`
- **`init.go`**: Add `PreRunE` to skip parent initialization when config doesn't exist yet
- **Logger simplification**: Remove individual logger creation across CLI commands

### Service Layer Refactoring  
- **`daemon.go`**: Remove manual logger/config management, use global app state
- **`closed_issue_cleanup.go`**: Migrate from direct zap to `logging.Logger` interface
- **Dependency injection**: Simplify service creation by leveraging singleton pattern

### Configuration Enhancements
- **Log format support**: Add `format` field to LogConfig (text/json)
- **Template updates**: Include log format configuration in generated config templates

### Testing Improvements
- **Test helper**: Add `app.TestHelper` for consistent test initialization
- **Test coverage**: Fix all failing tests without using skip
- **App state management**: Proper reset and cleanup in test environments

## Test Results

All tests pass successfully:
```bash
make test
# ✅ All packages pass
```

## Breaking Changes

This introduces a singleton pattern that changes how Config and Logger are accessed throughout the application. However, the external API remains unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)