### PR TITLE
fix: Repository設定を必須にし、QueueManager作成失敗時にエラー終了するよう修正

### DIFF
--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -30,9 +30,10 @@ Use -v/--verbose flag to enable debug logging.`,
 }
 
 func runStart(cmd *cobra.Command, args []string, daemon bool) error {
-	// Create service using global LogFactory
+	// Create service using global LogFactory and Config
 	// (app is already initialized with proper log level)
-	daemonService := service.NewDaemonService(app.LogFactory())
+	cfg := app.Config()
+	daemonService := service.NewDaemonServiceWithConfig(cfg, app.LogFactory())
 	return runStartWithService(cmd, args, daemon, daemonService)
 }
 

--- a/internal/service/daemon.go
+++ b/internal/service/daemon.go
@@ -71,6 +71,27 @@ func NewDaemonService(logFactory *logging.Factory) DaemonService {
 	return service
 }
 
+// NewDaemonServiceWithConfig creates a new daemon service with specific config
+func NewDaemonServiceWithConfig(cfg *config.Config, logFactory *logging.Factory) DaemonService {
+	logger := logFactory.CreateComponentLogger("daemon")
+	ctx := context.Background()
+	logger.Info(ctx, "NewDaemonService called")
+
+	serviceBuilder := builder.NewServiceBuilder(logFactory).WithConfig(cfg)
+	logger.Info(ctx, "ServiceBuilder created")
+
+	service, err := serviceBuilder.Build(ctx)
+	if err != nil {
+		logger.Error(ctx, "Failed to create daemon service",
+			logging.Field{Key: "error", Value: err.Error()},
+		)
+		panic(fmt.Sprintf("Failed to build daemon service: %v", err))
+	}
+
+	logger.Info(ctx, "ServiceBuilder.Build succeeded")
+	return service
+}
+
 // NewDaemonServiceWithDependencies creates daemon service with injected dependencies
 func NewDaemonServiceWithDependencies(
 	workDir string,

--- a/internal/service/daemon_test.go
+++ b/internal/service/daemon_test.go
@@ -22,8 +22,32 @@ func TestNewDaemonService(t *testing.T) {
 	helper := app.NewTestHelper(t)
 	helper.InitializeForTest()
 
-	// Create service with global LogFactory
-	service := NewDaemonService(app.LogFactory())
+	// Test NewDaemonService without config (should use defaults and fail for repository requirement)
+	assert.Panics(t, func() {
+		NewDaemonService(app.LogFactory())
+	})
+}
+
+func TestNewDaemonServiceWithConfig(t *testing.T) {
+	// Initialize app for testing
+	helper := app.NewTestHelper(t)
+	helper.InitializeForTest()
+
+	// Test NewDaemonServiceWithConfig with valid config
+	cfg := &config.Config{
+		GitHub: config.GitHubConfig{
+			Repository: "douhashi/soba-cli",
+		},
+		Workflow: config.WorkflowConfig{
+			Interval: 20,
+		},
+		Git: config.GitConfig{
+			WorktreeBasePath: ".git/soba/worktrees",
+		},
+	}
+
+	// Create service with config and LogFactory
+	service := NewDaemonServiceWithConfig(cfg, app.LogFactory())
 	assert.NotNil(t, service)
 }
 

--- a/internal/service/log_level_test.go
+++ b/internal/service/log_level_test.go
@@ -144,8 +144,9 @@ log:
 				Verbose:  tt.verbose,
 			})
 
-			// Create daemon service with global LogFactory
-			daemonService := NewDaemonService(app.LogFactory())
+			// Create daemon service with config and global LogFactory
+			cfg := app.Config()
+			daemonService := NewDaemonServiceWithConfig(cfg, app.LogFactory())
 
 			// The log level should be propagated correctly
 			assert.NotNil(t, daemonService)


### PR DESCRIPTION
## 問題

queue managerの作成で以下の問題が発生していました：

```
2025-09-23 13:56:47.591 [WARN ] Skipping queue manager creation - owner or repo is empty component=dependency-resolver
```

- `NewDaemonService`で`ServiceBuilder`に設定が渡されず、repository情報が空文字になっていた
- QueueManager作成が失敗しても警告で終了し、エラー終了しなかった

## 修正内容

### 1. 設定の正しい受け渡し
- `NewDaemonServiceWithConfig`関数を追加し、設定を適切に渡すよう修正
- `start`コマンドで`app.Config()`を使用して設定を渡すよう変更

### 2. QueueManager作成を必須化
- repository設定が空の場合はエラー終了するよう変更
- 以下のように本質的なエラーハンドリングを実装：

```go
if owner == "" || repo == "" {
    r.logger.Error(ctx, "Repository configuration is required but not provided",
        logging.Field{Key: "repository", Value: r.config.GitHub.Repository},
        logging.Field{Key: "owner", Value: owner},
        logging.Field{Key: "repo", Value: repo},
    )
    return nil, fmt.Errorf("repository configuration is required: owner=%q repo=%q (repository=%q)", owner, repo, r.config.GitHub.Repository)
}
```

### 3. テストコードの修正
- 変更に対応したテストケースを更新
- 適切な設定を使用するよう修正

## 結果

修正後は正常にQueueManagerが作成されます：

```
2025-09-23 14:09:31.761 [INFO ] Repository config repository=douhashi/soba-cli owner=douhashi repo=soba-cli
2025-09-23 14:09:31.761 [INFO ] Creating queue manager owner=douhashi repo=soba-cli  
2025-09-23 14:09:31.761 [INFO ] Queue manager set to IssueWatcher
```

## Test plan

- [x] 全テストの実行とパス確認
- [x] `soba start`コマンドでQueueManagerが正常に作成されることを確認
- [x] 設定が不正な場合のエラーハンドリング確認

🤖 Generated with [Claude Code](https://claude.ai/code)