### PR TITLE
fix: soba log でログファイルが見つからない問題を修正 (#116)

### DIFF
--- a/internal/service/daemon.go
+++ b/internal/service/daemon.go
@@ -232,8 +232,8 @@ func (d *daemonService) StartForeground(ctx context.Context, cfg *config.Config)
 	}
 
 	// ログ初期化後ログ出力を開始
-
 	if logPath != "" {
+		// 初期メッセージを出力してログファイルを確実に作成
 		d.logger.Info(ctx, "Starting Issue monitoring in foreground mode",
 			logging.Field{Key: "logFile", Value: logPath},
 		)
@@ -374,7 +374,13 @@ func (d *daemonService) StartDaemon(ctx context.Context, cfg *config.Config) err
 		return err
 	}
 
-	// ログ初期化後ログ出力を開始
+	// ログ初期化後、初期メッセージを出力してログファイルを確実に作成
+	if logPath != "" {
+		d.logger.Info(ctx, "Starting daemon process",
+			logging.Field{Key: "logFile", Value: logPath},
+			logging.Field{Key: "pid", Value: os.Getpid()},
+		)
+	}
 
 	// tmuxセッションを初期化
 	if err := d.initializeTmuxSession(cfg); err != nil {

--- a/pkg/logging/factory_test.go
+++ b/pkg/logging/factory_test.go
@@ -299,6 +299,45 @@ func TestRotatingFileWriter(t *testing.T) {
 		_, err = os.Stat(logFile)
 		assert.NoError(t, err)
 	})
+
+	t.Run("should create log file immediately without writing", func(t *testing.T) {
+		// Arrange
+		tempDir := t.TempDir()
+		logFile := filepath.Join(tempDir, "immediate.log")
+
+		// Act
+		writer, err := logging.NewRotatingFileWriter(logFile)
+
+		// Assert
+		require.NoError(t, err)
+		assert.NotNil(t, writer)
+
+		// File should be created immediately even without writing
+		_, err = os.Stat(logFile)
+		assert.NoError(t, err, "Log file should be created immediately")
+	})
+
+	t.Run("should create directory if not exists", func(t *testing.T) {
+		// Arrange
+		tempDir := t.TempDir()
+		logDir := filepath.Join(tempDir, "nested", "logs")
+		logFile := filepath.Join(logDir, "app.log")
+
+		// Act
+		writer, err := logging.NewRotatingFileWriter(logFile)
+
+		// Assert
+		require.NoError(t, err)
+		assert.NotNil(t, writer)
+
+		// Directory should be created
+		_, err = os.Stat(logDir)
+		assert.NoError(t, err, "Log directory should be created")
+
+		// File should be created
+		_, err = os.Stat(logFile)
+		assert.NoError(t, err, "Log file should be created")
+	})
 }
 
 func TestPrettyTextHandler(t *testing.T) {

--- a/pkg/logging/rotation.go
+++ b/pkg/logging/rotation.go
@@ -2,12 +2,29 @@ package logging
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // NewRotatingFileWriter creates a writer that rotates log files
 func NewRotatingFileWriter(filename string) (io.Writer, error) {
+	// ディレクトリが存在しない場合は作成
+	dir := filepath.Dir(filename)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+
+	// ログファイルが存在しない場合は空ファイルを作成
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return nil, err
+		}
+		file.Close()
+	}
+
 	return &lumberjack.Logger{
 		Filename:   filename,
 		MaxSize:    100, // megabytes


### PR DESCRIPTION
## 実装完了

fixes #116

### 変更内容
- `NewRotatingFileWriter` でディレクトリとファイルを即座に作成するよう修正
- デーモン/フォアグラウンド起動時に初期メッセージを出力してログファイル作成を確実に
- lumberjackライブラリの遅延作成仕様に対応

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス（一部のテストは既存の問題のためスキップ）

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし

### 修正内容の詳細
1. **`pkg/logging/rotation.go`**:
   - ディレクトリが存在しない場合は作成
   - ログファイルが存在しない場合は空ファイルを作成

2. **`internal/service/daemon.go`**:
   - フォアグラウンド起動時に初期メッセージ出力を追加
   - デーモン起動時（子プロセス）に初期メッセージ出力を追加

3. **テストケース追加**:
   - ログファイルが即座に作成されることを確認するテストを追加
   - ディレクトリが存在しない場合の作成テストを追加