### PR TITLE
feat: 設定ファイルなしでもデフォルト設定でログファイルを作成 (#118)

### DIFF
--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -103,10 +103,13 @@ log:
 	helper := app.NewTestHelper(t)
 	helper.InitializeForTestWithOptions(minimalConfigPath, nil)
 
-	// Now test that accessing a non-existent config returns an error
-	_, err := config.Load(nonExistentPath)
-	require.Error(t, err)
-	assert.Contains(t, strings.ToLower(err.Error()), "not found")
+	// Now test that accessing a non-existent config returns default config
+	cfg, err := config.Load(nonExistentPath)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+	// Verify defaults are set
+	assert.Equal(t, 20, cfg.Workflow.Interval)
+	assert.Equal(t, ".git/soba/worktrees", cfg.Git.WorktreeBasePath)
 }
 
 func TestRunConfig_InvalidYAML(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,7 +45,7 @@ development workflows through seamless integration with Claude Code AI.`,
 				cmdName = cmd.Name()
 			}
 
-			if cmdName == "init" || cmdName == "version" || cmdName == "stop" {
+			if cmdName == "init" || cmdName == "version" || cmdName == "stop" || cmdName == "log" {
 				return nil
 			}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -163,9 +163,24 @@ github:
 }
 
 func TestLoadConfigFileNotFound(t *testing.T) {
-	_, err := Load("/nonexistent/path/config.yml")
-	if err == nil {
-		t.Errorf("Expected error for nonexistent file, got nil")
+	cfg, err := Load("/nonexistent/path/config.yml")
+	if err != nil {
+		t.Errorf("Expected no error for nonexistent file (should return defaults), got %v", err)
+	}
+	if cfg == nil {
+		t.Errorf("Expected default config, got nil")
+	}
+
+	// Verify defaults are set
+	if cfg != nil && cfg.Workflow.Interval != 20 {
+		t.Errorf("Default workflow interval = %v, want 20", cfg.Workflow.Interval)
+	}
+	if cfg != nil && cfg.Git.WorktreeBasePath != ".git/soba/worktrees" {
+		t.Errorf("Default git worktree base path = %v, want .git/soba/worktrees", cfg.Git.WorktreeBasePath)
+	}
+	expectedLogPath := fmt.Sprintf(".soba/logs/soba-%d.log", os.Getpid())
+	if cfg != nil && cfg.Log.OutputPath != expectedLogPath {
+		t.Errorf("Default log output_path = %v, want %v", cfg.Log.OutputPath, expectedLogPath)
 	}
 }
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/douhashi/soba/internal/config"
@@ -56,11 +59,17 @@ func MustInitializeWithOptions(configPath string, opts *InitOptions) {
 		logLevel = "warn" // Default
 	}
 
+	// Replace ${PID} in log output path
+	logOutputPath := cfg.Log.OutputPath
+	if strings.Contains(logOutputPath, "${PID}") {
+		logOutputPath = strings.ReplaceAll(logOutputPath, "${PID}", strconv.Itoa(os.Getpid()))
+	}
+
 	// Create Logger Factory
 	logFactory, err = logging.NewFactory(logging.Config{
 		Level:        logLevel,
 		Format:       cfg.Log.Format,
-		Output:       cfg.Log.OutputPath,
+		Output:       logOutputPath,
 		AlsoToStdout: true,
 	})
 	if err != nil {


### PR DESCRIPTION
## 実装完了

fixes #118

### 変更内容
- `config.Load()`で設定ファイルが存在しない場合にデフォルト設定を返すよう変更
- `app.MustInitializeWithOptions()`で`${PID}`をプロセスIDで置換する処理を追加
- `soba log`コマンドが設定ファイルなしでも動作するように修正
- 関連テストを更新

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし

### 動作確認
```bash
# 設定ファイルなしでもログファイルが作成される
rm -rf .soba
bin/soba init
bin/soba start -vd
ls -la .soba/logs/
# soba-<PID>.log が正しく作成される
bin/soba log
# ログが正常に表示される
```

### 修正内容の詳細
1. **設定ファイルがない場合のデフォルト設定返却**
   - `internal/config/config.go`: `Load()`関数で`os.IsNotExist(err)`の場合にデフォルト設定を生成

2. **PID置換の実装**
   - `pkg/app/app.go`: ログファクトリー作成前に`${PID}`をプロセスIDで置換
   - `internal/config/config.go`: `expandEnvVarsWithConfig()`で`${PID}`を特別扱い

3. **CLIコマンドの調整**
   - `internal/cli/root.go`: `log`コマンドも初期化をスキップするよう修正

これにより、設定ファイルがなくても基本的なログ機能が動作するようになりました。