### PR TITLE
feat: Internationalize Japanese output strings to English (#126)

### DIFF
--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -28,13 +28,13 @@ func newOpenCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "open",
-		Short: "tmuxセッションを開く",
-		Long: `configから算出されるセッション名でtmuxセッションを開きます。
+		Short: "Open tmux session",
+		Long: `Opens a tmux session with the session name calculated from the configuration.
 
-既存のセッションが存在する場合はアタッチし、
-存在しない場合は新規作成してアタッチします。
+If an existing session exists, it attaches to it.
+If no session exists, it creates a new one and attaches to it.
 
-設定ファイルのgithub.repositoryからセッション名を自動算出します。`,
+The session name is automatically calculated from the github.repository setting in the configuration file.`,
 		RunE: o.runOpen,
 	}
 
@@ -46,13 +46,13 @@ func (o *openCmd) runOpen(cmd *cobra.Command, args []string) error {
 	sessionName := o.generateSessionName(repository)
 
 	if o.tmuxClient.SessionExists(sessionName) {
-		fmt.Printf("セッション '%s' にアタッチします\n", sessionName)
+		fmt.Printf("Attaching to session '%s'\n", sessionName)
 		return o.attachToSession(sessionName)
 	}
 
-	fmt.Printf("セッション '%s' を作成します\n", sessionName)
+	fmt.Printf("Creating session '%s'\n", sessionName)
 	if err := o.tmuxClient.CreateSession(sessionName); err != nil {
-		return fmt.Errorf("セッションの作成に失敗しました: %w", err)
+		return fmt.Errorf("Failed to create session: %w", err)
 	}
 
 	return o.attachToSession(sessionName)

--- a/internal/cli/open_test.go
+++ b/internal/cli/open_test.go
@@ -91,27 +91,27 @@ func TestGenerateSessionName(t *testing.T) {
 		expected   string
 	}{
 		{
-			name:       "正常なリポジトリ形式",
+			name:       "Normal repository format",
 			repository: "douhashi/soba",
 			expected:   "soba-douhashi-soba",
 		},
 		{
-			name:       "空のリポジトリ",
+			name:       "Empty repository",
 			repository: "",
 			expected:   "soba",
 		},
 		{
-			name:       "不正な形式（スラッシュなし）",
+			name:       "Invalid format (no slash)",
 			repository: "invalid-repo",
 			expected:   "soba",
 		},
 		{
-			name:       "不正な形式（スラッシュのみ）",
+			name:       "Invalid format (slash only)",
 			repository: "/",
 			expected:   "soba",
 		},
 		{
-			name:       "長いリポジトリ名",
+			name:       "Long repository name",
 			repository: "very-long-owner/very-long-repository-name",
 			expected:   "soba-very-long-owner-very-long-repository-name",
 		},
@@ -191,7 +191,7 @@ func TestRunOpen_CreateSessionError(t *testing.T) {
 	err := cmd.runOpen(nil, []string{})
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "セッションの作成に失敗しました")
+	assert.Contains(t, err.Error(), "Failed to create session")
 	mockTmux.AssertExpectations(t)
 }
 
@@ -221,6 +221,6 @@ func TestNewOpenCmd(t *testing.T) {
 	cmd := newOpenCmd()
 
 	assert.Equal(t, "open", cmd.Use)
-	assert.Equal(t, "tmuxセッションを開く", cmd.Short)
+	assert.Equal(t, "Open tmux session", cmd.Short)
 	assert.NotEmpty(t, cmd.Long)
 }

--- a/internal/greeting/greeting.go
+++ b/internal/greeting/greeting.go
@@ -10,10 +10,10 @@ func Hello(name string) string {
 	return fmt.Sprintf("Hello, %s!", name)
 }
 
-// JapaneseGreeting returns a greeting message in Japanese
+// JapaneseGreeting returns a greeting message (now in English for internationalization)
 func JapaneseGreeting(name string) string {
 	if name == "" {
-		name = "ゲスト"
+		name = "Guest"
 	}
-	return fmt.Sprintf("こんにちは、%sさん！", name)
+	return fmt.Sprintf("Hello, %s!", name)
 }

--- a/internal/greeting/greeting_test.go
+++ b/internal/greeting/greeting_test.go
@@ -11,17 +11,17 @@ func TestHello(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "挨拶（名前あり）",
+			name:     "Greeting with name",
 			input:    "World",
 			expected: "Hello, World!",
 		},
 		{
-			name:     "挨拶（空文字）",
+			name:     "Greeting with empty string",
 			input:    "",
 			expected: "Hello, Guest!",
 		},
 		{
-			name:     "挨拶（日本語）",
+			name:     "Greeting with Japanese characters",
 			input:    "世界",
 			expected: "Hello, 世界!",
 		},
@@ -44,14 +44,14 @@ func TestJapaneseGreeting(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "日本語挨拶（名前あり）",
-			input:    "太郎",
-			expected: "こんにちは、太郎さん！",
+			name:     "Japanese greeting with name",
+			input:    "Taro",
+			expected: "Hello, Taro!",
 		},
 		{
-			name:     "日本語挨拶（空文字）",
+			name:     "Japanese greeting with empty string",
 			input:    "",
-			expected: "こんにちは、ゲストさん！",
+			expected: "Hello, Guest!",
 		},
 	}
 


### PR DESCRIPTION
## 実装完了

fixes #126

### 変更内容
- `internal/cli/open.go` のCLIコマンド説明・メッセージを英語化
  - コマンドのShort/Long descriptionを英語に変更
  - tmuxセッション作成/アタッチ時のメッセージを英語化
  - エラーメッセージを英語化
- `internal/greeting/greeting.go` のJapaneseGreeting関数を英語出力に変更
  - 互換性のため関数名は維持し、出力のみ英語化
- テストファイルのテスト名・説明を英語化

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス (`make test`で全テストパス確認)

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] TDD方式での開発（Red→Green→Refactor）