### PR TITLE
feat: リリース自動化の設定 (#128)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  GO_VERSION: '1.23'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Run tests
+      run: go test -v ./...
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v6
+      with:
+        version: latest
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,78 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+
+builds:
+  - id: soba
+    main: ./cmd/soba/main.go
+    binary: soba
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
+archives:
+  - id: archive
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_
+      {{- if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end }}
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  version_template: '{{ incpatch .Version }}-next'
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - '^style:'
+      - '^refactor:'
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: douhashi
+    name: soba
+  draft: false
+  prerelease: auto
+  mode: append
+  header: |
+    ## What's Changed
+  footer: |
+    **Full Changelog**: https://github.com/douhashi/soba/compare/{{ .PreviousTag }}...{{ .Tag }}
+  name_template: '{{.ProjectName}}-v{{.Version}}'


### PR DESCRIPTION
## 実装完了

fixes #128

### 変更内容
- GoReleaser設定ファイル(`.goreleaser.yml`)を追加
- GitHub Actionsのリリースワークフロー(`.github/workflows/release.yml`)を追加
- タグプッシュ時(`v*`パターン)の自動リリース機能を実装
- マルチプラットフォーム向けバイナリビルドの設定を追加（Linux/macOS/Windows、amd64/arm64）

### 実装詳細

#### GoReleaser設定 (`.goreleaser.yml`)
- ビルド対象: `cmd/soba/main.go`
- LDFLAGSによるバージョン情報埋め込み（version, commit, date）
- 対象OS/Arch: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
- チェックサム生成: SHA256
- リリースノート自動生成（conventional commits形式）

#### GitHub Actionsワークフロー (`.github/workflows/release.yml`)
- トリガー: `v*`形式のタグプッシュ
- Goバージョン: 1.23（既存のtest.ymlと統一）
- ステップ: チェックアウト → Go設定 → テスト実行 → GoReleaser実行
- 権限: contents:write（リリース作成に必要）

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス (`make test`実行済み)

### 確認事項
- [x] 実装計画に沿った実装
- [x] 既存のテストが全てパス
- [x] 既存機能への影響なし
- [x] Goバージョンを既存環境と統一（1.23）