### PR TITLE
feat: soba start のデフォルト動作をデーモンモードに変更 (#129)

### DIFF
--- a/docs/business/operations.md
+++ b/docs/business/operations.md
@@ -45,12 +45,12 @@ github:
 
 ### ワークフロー起動
 ```bash
-# フォアグラウンドで起動（デフォルト）
+# デーモンモードで起動（デフォルト）
 soba start
 
-# デーモンとして起動
-soba start -d
-soba start --daemon
+# フォアグラウンドで起動
+soba start -f
+soba start --foreground
 
 # デバッグモード
 soba start --verbose
@@ -114,8 +114,8 @@ gh issue edit 123 --add-label "soba:todo"
 
 ### 1. 継続的開発
 ```bash
-# デーモン起動
-soba start --daemon
+# デーモン起動（デフォルト）
+soba start
 
 # Issueを順次作成・ラベル付与
 # → 自動的に処理される

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -20,12 +20,12 @@ import (
 func TestNewStartCmd(t *testing.T) {
 	cmd := newStartCmd()
 	assert.Equal(t, "start", cmd.Use)
-	assert.Equal(t, "Start Issue monitoring in foreground or daemon mode", cmd.Short)
+	assert.Equal(t, "Start Issue monitoring (daemon mode by default)", cmd.Short)
 
 	// フラグをテスト
-	daemonFlag := cmd.Flags().Lookup("daemon")
-	require.NotNil(t, daemonFlag)
-	assert.Equal(t, "bool", daemonFlag.Value.Type())
+	foregroundFlag := cmd.Flags().Lookup("foreground")
+	require.NotNil(t, foregroundFlag)
+	assert.Equal(t, "bool", foregroundFlag.Value.Type())
 
 }
 
@@ -76,7 +76,7 @@ workflow:
 	}
 
 	cmd := &cobra.Command{}
-	err = runStartWithService(cmd, []string{}, false, mockService)
+	err = runStartWithService(cmd, []string{}, true, mockService)
 	assert.NoError(t, err)
 	assert.True(t, mockService.startForegroundCalled)
 }
@@ -128,7 +128,7 @@ workflow:
 	}
 
 	cmd := &cobra.Command{}
-	err = runStartWithService(cmd, []string{}, true, mockService)
+	err = runStartWithService(cmd, []string{}, false, mockService)
 	assert.NoError(t, err)
 	assert.True(t, mockService.startDaemonCalled)
 }
@@ -200,11 +200,11 @@ func TestRunStart_LogFileCreation(t *testing.T) {
 	}{
 		{
 			name:       "Foreground mode creates log file",
-			daemonMode: false,
+			daemonMode: true,
 		},
 		{
 			name:       "Daemon mode creates log file",
-			daemonMode: true,
+			daemonMode: false,
 		},
 	}
 
@@ -285,9 +285,9 @@ log:
 			assert.NoError(t, err)
 
 			if tt.daemonMode {
-				assert.True(t, mockService.startDaemonCalled)
-			} else {
 				assert.True(t, mockService.startForegroundCalled)
+			} else {
+				assert.True(t, mockService.startDaemonCalled)
 			}
 		})
 	}


### PR DESCRIPTION
## 実装完了

fixes #129

### 変更内容
- `soba start`のデフォルト動作をデーモンモードに変更
- `--daemon`フラグを削除し、`--foreground`フラグを新規追加
- ヘルプメッセージとドキュメントを更新

### 実装詳細
1. **CLIフラグの変更**
   - `internal/cli/start.go`: `--daemon`フラグを`--foreground`フラグに置き換え
   - デフォルト値の論理を反転（デフォルトでデーモンモード）

2. **テストの更新**
   - `internal/cli/start_test.go`: 新しい挙動に合わせてテストケースを修正
   - フラグ名の変更と期待値の反転

3. **ドキュメントの更新**
   - `docs/business/operations.md`: 新しいコマンドオプションの説明を更新

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] ドキュメント更新済み