### PR TITLE
fix: soba init でリポジトリの設定値が固定値で出力される問題を修正 (#134)

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,12 +61,10 @@ func runInitWithClient(ctx context.Context, _ []string, gitHubClient GitHubLabel
 	// Try to get repository information
 	repository, err := gitClient.GetRepository()
 	if err != nil {
-		// Log warning but continue with default
-		log.Warn(ctx, "Failed to detect repository from git remote", logging.Field{Key: "error", Value: err.Error()})
-		repository = ""
-	} else {
-		log.Info(ctx, "Detected repository from git remote", logging.Field{Key: "repository", Value: repository})
+		// Repository is required for soba to work properly
+		return fmt.Errorf("failed to detect repository from git remote. Please ensure git remote origin is configured: %w", err)
 	}
+	log.Info(ctx, "Detected repository from git remote", logging.Field{Key: "repository", Value: repository})
 
 	// Define paths
 	sobaDir := filepath.Join(currentDir, ".soba")

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -23,10 +23,15 @@ func TestInitCommand(t *testing.T) {
 		defer os.Chdir(oldDir)
 		require.NoError(t, os.Chdir(tempDir))
 
-		// Initialize git repository
+		// Initialize git repository with remote
 		gitCmd := exec.Command("git", "init")
 		output, err := gitCmd.CombinedOutput()
 		require.NoError(t, err, "Failed to init git repository: %s", string(output))
+
+		// Add remote origin
+		gitCmd = exec.Command("git", "remote", "add", "origin", "https://github.com/test-owner/test-repo.git")
+		output, err = gitCmd.CombinedOutput()
+		require.NoError(t, err, "Failed to add git remote: %s", string(output))
 
 		// Execute
 		cmd := newRootCmd()
@@ -50,6 +55,7 @@ func TestInitCommand(t *testing.T) {
 		assert.NotEmpty(t, content)
 		assert.Contains(t, string(content), "github:")
 		assert.Contains(t, string(content), "workflow:")
+		assert.Contains(t, string(content), "test-owner/test-repo")
 	})
 
 	t.Run("should not overwrite existing config file", func(t *testing.T) {
@@ -59,10 +65,15 @@ func TestInitCommand(t *testing.T) {
 		defer os.Chdir(oldDir)
 		require.NoError(t, os.Chdir(tempDir))
 
-		// Initialize git repository
+		// Initialize git repository with remote
 		gitCmd := exec.Command("git", "init")
 		output, err := gitCmd.CombinedOutput()
 		require.NoError(t, err, "Failed to init git repository: %s", string(output))
+
+		// Add remote origin
+		gitCmd = exec.Command("git", "remote", "add", "origin", "https://github.com/test-owner/test-repo.git")
+		output, err = gitCmd.CombinedOutput()
+		require.NoError(t, err, "Failed to add git remote: %s", string(output))
 
 		// Create existing config file
 		sobaDir := filepath.Join(tempDir, ".soba")
@@ -104,10 +115,15 @@ func TestInitCommand(t *testing.T) {
 		defer os.Chdir(oldDir)
 		require.NoError(t, os.Chdir(tempDir))
 
-		// Initialize git repository
+		// Initialize git repository with remote
 		gitCmd := exec.Command("git", "init")
 		output, err := gitCmd.CombinedOutput()
 		require.NoError(t, err, "Failed to init git repository: %s", string(output))
+
+		// Add remote origin
+		gitCmd = exec.Command("git", "remote", "add", "origin", "https://github.com/test-owner/test-repo.git")
+		output, err = gitCmd.CombinedOutput()
+		require.NoError(t, err, "Failed to add git remote: %s", string(output))
 
 		// Create directory with no write permission
 		sobaDir := filepath.Join(tempDir, ".soba")
@@ -136,10 +152,15 @@ func TestInitCommand(t *testing.T) {
 		defer os.Chdir(oldDir)
 		require.NoError(t, os.Chdir(tempDir))
 
-		// Initialize git repository
+		// Initialize git repository with remote
 		gitCmd := exec.Command("git", "init")
 		output, err := gitCmd.CombinedOutput()
 		require.NoError(t, err, "Failed to init git repository: %s", string(output))
+
+		// Add remote origin
+		gitCmd = exec.Command("git", "remote", "add", "origin", "https://github.com/test-owner/test-repo.git")
+		output, err = gitCmd.CombinedOutput()
+		require.NoError(t, err, "Failed to add git remote: %s", string(output))
 
 		// Execute init command
 		cmd := newRootCmd()
@@ -162,7 +183,7 @@ func TestInitCommand(t *testing.T) {
 
 		// Verify some basic fields
 		assert.Equal(t, "gh", loadedConfig.GitHub.AuthMethod)
-		assert.Equal(t, "douhashi/soba-cli", loadedConfig.GitHub.Repository)
+		assert.Equal(t, "test-owner/test-repo", loadedConfig.GitHub.Repository)
 		assert.Equal(t, 20, loadedConfig.Workflow.Interval)
 		assert.True(t, loadedConfig.Workflow.UseTmux)
 		assert.Equal(t, ".git/soba/worktrees", loadedConfig.Git.WorktreeBasePath)
@@ -175,10 +196,15 @@ func TestInitCommand(t *testing.T) {
 		defer os.Chdir(oldDir)
 		require.NoError(t, os.Chdir(tempDir))
 
-		// Initialize git repository
+		// Initialize git repository with remote
 		gitCmd := exec.Command("git", "init")
 		output, err := gitCmd.CombinedOutput()
 		require.NoError(t, err, "Failed to init git repository: %s", string(output))
+
+		// Add remote origin
+		gitCmd = exec.Command("git", "remote", "add", "origin", "https://github.com/test-owner/test-repo.git")
+		output, err = gitCmd.CombinedOutput()
+		require.NoError(t, err, "Failed to add git remote: %s", string(output))
 
 		// Mock GitHub client
 		mockClient := &MockGitHubClient{
@@ -192,30 +218,30 @@ func TestInitCommand(t *testing.T) {
 		// Assert
 		assert.NoError(t, err)
 
-		// Should have attempted to create labels for default repository
+		// Should have attempted to create labels for detected repository
 		assert.GreaterOrEqual(t, len(mockClient.ListLabelsCalls), 1, "Should call ListLabels at least once")
 
 		if len(mockClient.ListLabelsCalls) > 0 {
 			// Verify first call is to list existing labels
 			listCall := mockClient.ListLabelsCalls[0]
-			assert.Equal(t, "douhashi", listCall.Owner)
-			assert.Equal(t, "soba-cli", listCall.Repo)
+			assert.Equal(t, "test-owner", listCall.Owner)
+			assert.Equal(t, "test-repo", listCall.Repo)
 		}
 	})
 
-	t.Run("should skip label creation if no repository configured", func(t *testing.T) {
+	t.Run("should require git remote to be configured", func(t *testing.T) {
 		// Setup
 		tempDir := t.TempDir()
 		oldDir, _ := os.Getwd()
 		defer os.Chdir(oldDir)
 		require.NoError(t, os.Chdir(tempDir))
 
-		// Initialize git repository
+		// Initialize git repository without remote
 		gitCmd := exec.Command("git", "init")
 		output, err := gitCmd.CombinedOutput()
 		require.NoError(t, err, "Failed to init git repository: %s", string(output))
 
-		// Execute with no config file (should create default config)
+		// Execute init command
 		cmd := newRootCmd()
 		cmd.SetArgs([]string{"init"})
 
@@ -225,9 +251,9 @@ func TestInitCommand(t *testing.T) {
 
 		err = cmd.Execute()
 
-		// Assert - should succeed even without GitHub configuration
-		assert.NoError(t, err)
-		assert.Contains(t, buf.String(), "Successfully created config file")
+		// Assert - should fail without git remote
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "git remote")
 	})
 
 	t.Run("should handle GitHub API errors gracefully", func(t *testing.T) {
@@ -237,21 +263,89 @@ func TestInitCommand(t *testing.T) {
 		defer os.Chdir(oldDir)
 		require.NoError(t, os.Chdir(tempDir))
 
-		// Initialize git repository
+		// Initialize git repository with remote
 		gitCmd := exec.Command("git", "init")
 		output, err := gitCmd.CombinedOutput()
 		require.NoError(t, err, "Failed to init git repository: %s", string(output))
+
+		// Add remote origin
+		gitCmd = exec.Command("git", "remote", "add", "origin", "https://github.com/test-owner/test-repo.git")
+		output, err = gitCmd.CombinedOutput()
+		require.NoError(t, err, "Failed to add git remote: %s", string(output))
 
 		// Mock GitHub client that returns errors
 		mockClient := &MockGitHubClient{
 			ListLabelsError: assert.AnError,
 		}
 
-		// Execute with mock client (this will create default config)
+		// Execute with mock client
 		err = runInitWithClient(context.Background(), []string{}, mockClient)
 
 		// Assert - should not fail completely, but log the error
 		assert.NoError(t, err, "Init should not fail due to GitHub API errors")
+	})
+
+	t.Run("should fail when no git remote is configured", func(t *testing.T) {
+		// Setup
+		tempDir := t.TempDir()
+		oldDir, _ := os.Getwd()
+		defer os.Chdir(oldDir)
+		require.NoError(t, os.Chdir(tempDir))
+
+		// Initialize git repository without remote
+		gitCmd := exec.Command("git", "init")
+		output, err := gitCmd.CombinedOutput()
+		require.NoError(t, err, "Failed to init git repository: %s", string(output))
+
+		// Execute
+		cmd := newRootCmd()
+		cmd.SetArgs([]string{"init"})
+
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+
+		err = cmd.Execute()
+
+		// Assert - should fail with clear error message
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "git remote")
+	})
+
+	t.Run("should use detected repository from git remote", func(t *testing.T) {
+		// Setup
+		tempDir := t.TempDir()
+		oldDir, _ := os.Getwd()
+		defer os.Chdir(oldDir)
+		require.NoError(t, os.Chdir(tempDir))
+
+		// Initialize git repository with remote
+		gitCmd := exec.Command("git", "init")
+		output, err := gitCmd.CombinedOutput()
+		require.NoError(t, err, "Failed to init git repository: %s", string(output))
+
+		// Add remote origin
+		gitCmd = exec.Command("git", "remote", "add", "origin", "https://github.com/test-owner/test-repo.git")
+		output, err = gitCmd.CombinedOutput()
+		require.NoError(t, err, "Failed to add git remote: %s", string(output))
+
+		// Execute
+		cmd := newRootCmd()
+		cmd.SetArgs([]string{"init"})
+
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+
+		err = cmd.Execute()
+		require.NoError(t, err)
+
+		// Verify config file has correct repository
+		configPath := filepath.Join(tempDir, ".soba", "config.yml")
+		content, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "test-owner/test-repo")
+		assert.NotContains(t, string(content), "douhashi/soba-cli")
 	})
 }
 

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -29,7 +29,7 @@ func GenerateTemplateWithOptions(opts *TemplateOptions) string {
 func generateFallbackTemplate() string {
 	return `# GitHub settings
 github:
-  repository: douhashi/soba-cli
+  repository:
 
 workflow:
   interval: 20

--- a/internal/config/template_manager.go
+++ b/internal/config/template_manager.go
@@ -29,9 +29,7 @@ func (tm *templateManager) RenderTemplate(opts *TemplateOptions) (string, error)
 	if opts == nil {
 		opts = &TemplateOptions{}
 	}
-	if opts.Repository == "" {
-		opts.Repository = "douhashi/soba-cli"
-	}
+	// Repository should be set by the caller - no default value
 	if opts.LogLevel == "" {
 		opts.LogLevel = "info"
 	}

--- a/internal/config/template_manager_test.go
+++ b/internal/config/template_manager_test.go
@@ -72,14 +72,17 @@ func TestConfigTemplateManager_RenderTemplate(t *testing.T) {
 			},
 		},
 		{
-			name: "empty repository fallback to default",
+			name: "empty repository should remain empty",
 			options: &TemplateOptions{
 				Repository: "",
 				LogLevel:   "info",
 			},
 			wantContain: []string{
-				"repository: douhashi/soba-cli",
+				"repository: ",
 				"level: info",
+			},
+			wantNotContain: []string{
+				"douhashi/soba-cli",
 			},
 		},
 		{
@@ -94,11 +97,14 @@ func TestConfigTemplateManager_RenderTemplate(t *testing.T) {
 			},
 		},
 		{
-			name:    "nil options uses defaults",
+			name:    "nil options uses empty repository and default log level",
 			options: nil,
 			wantContain: []string{
-				"repository: douhashi/soba-cli",
+				"repository: ",
 				"level: info",
+			},
+			wantNotContain: []string{
+				"douhashi/soba-cli",
 			},
 		},
 	}

--- a/internal/config/template_test.go
+++ b/internal/config/template_test.go
@@ -34,7 +34,8 @@ func TestGenerateTemplate(t *testing.T) {
 
 		// Check default values are present
 		assert.Contains(t, template, "auth_method: gh")
-		assert.Contains(t, template, "repository: douhashi/soba-cli")
+		assert.Contains(t, template, "repository: ")
+		assert.NotContains(t, template, "douhashi/soba-cli")
 		assert.Contains(t, template, "interval: 20")
 		assert.Contains(t, template, "use_tmux: true")
 		assert.Contains(t, template, "auto_merge_enabled: true")
@@ -94,7 +95,7 @@ func TestGenerateTemplate(t *testing.T) {
 
 		// Verify structure is correct
 		assert.Equal(t, "gh", config.GitHub.AuthMethod)
-		assert.Equal(t, "douhashi/soba-cli", config.GitHub.Repository)
+		assert.Equal(t, "", config.GitHub.Repository)
 		assert.Equal(t, 20, config.Workflow.Interval)
 		assert.True(t, config.Workflow.UseTmux)
 		assert.True(t, config.Workflow.AutoMergeEnabled)
@@ -140,24 +141,26 @@ func TestGenerateTemplateWithOptions(t *testing.T) {
 
 		// Assert custom repository is used
 		assert.Contains(t, template, "repository: myorg/myrepo")
-		assert.NotContains(t, template, "repository: douhashi/soba-cli")
+		assert.NotContains(t, template, "douhashi/soba-cli")
 	})
 
-	t.Run("should use default values when opts is nil", func(t *testing.T) {
+	t.Run("should use empty repository when opts is nil", func(t *testing.T) {
 		template := GenerateTemplateWithOptions(nil)
 
-		// Assert default repository is used
-		assert.Contains(t, template, "repository: douhashi/soba-cli")
+		// Assert empty repository is used
+		assert.Contains(t, template, "repository: ")
+		assert.NotContains(t, template, "douhashi/soba-cli")
 	})
 
-	t.Run("should use default values when repository is empty", func(t *testing.T) {
+	t.Run("should use empty values when repository is empty", func(t *testing.T) {
 		opts := &TemplateOptions{
 			Repository: "",
 		}
 		template := GenerateTemplateWithOptions(opts)
 
-		// Assert default repository is used
-		assert.Contains(t, template, "repository: douhashi/soba-cli")
+		// Assert empty repository is used
+		assert.Contains(t, template, "repository: ")
+		assert.NotContains(t, template, "douhashi/soba-cli")
 	})
 
 	t.Run("generated template with custom options should be valid YAML", func(t *testing.T) {


### PR DESCRIPTION
## 実装完了

fixes #134

### 変更内容
- `soba init` コマンドで git remote から取得したリポジトリ名が正しく設定ファイルに反映されるよう修正
- git remote が設定されていない場合はエラーを返すように変更（soba はリポジトリ設定が必須のため）
- template_manager.go のデフォルト値 "douhashi/soba-cli" を削除
- フォールバックテンプレートの固定値も削除

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)