### PR TITLE
feat: soba init で SSH URL（ポート番号なし）のパースに対応 (#136)

### DIFF
--- a/internal/infra/git/client.go
+++ b/internal/infra/git/client.go
@@ -205,14 +205,22 @@ func ParseRepositoryFromURL(url string) (owner, repo string, err error) {
 		return "", "", errors.New("invalid SSH URL format")
 	}
 
-	// Handle SSH URL with protocol: ssh://git@github.com:22/owner/repo
+	// Handle SSH URL with protocol: ssh://git@github.com:22/owner/repo or ssh://git@github.com/owner/repo
 	if strings.HasPrefix(url, "ssh://git@github.com") {
 		// Find the path after github.com
 		idx := strings.Index(url, "github.com")
 		if idx >= 0 {
 			remaining := url[idx+len("github.com"):]
-			// Remove port if present
-			if strings.HasPrefix(remaining, ":") {
+
+			// Check if it's directly followed by path (no port)
+			if strings.HasPrefix(remaining, "/") {
+				parts := strings.Split(strings.TrimPrefix(remaining, "/"), "/")
+				if len(parts) == 2 {
+					// Format: /owner/repo
+					return parts[0], parts[1], nil
+				}
+			} else if strings.HasPrefix(remaining, ":") {
+				// Remove port if present
 				parts := strings.Split(remaining, "/")
 				if len(parts) >= 3 {
 					// Format: :22/owner/repo

--- a/internal/infra/git/client_test.go
+++ b/internal/infra/git/client_test.go
@@ -128,6 +128,20 @@ func TestClient_ParseRepositoryFromURL(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "SSH URL without port with .git",
+			url:       "ssh://git@github.com/owner/repo.git",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "SSH URL without port without .git",
+			url:       "ssh://git@github.com/owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
 			name:      "Invalid URL format",
 			url:       "not-a-valid-url",
 			wantOwner: "",
@@ -190,6 +204,15 @@ func TestClient_GetRepository(t *testing.T) {
 				runCommand(t, tmpDir, "git", "remote", "add", "origin", "git@github.com:douhashi/soba-cli.git")
 			},
 			wantRepo: "douhashi/soba-cli",
+			wantErr:  false,
+		},
+		{
+			name: "Get repository from SSH URL without port",
+			setupFunc: func(t *testing.T, tmpDir string) {
+				runCommand(t, tmpDir, "git", "init")
+				runCommand(t, tmpDir, "git", "remote", "add", "origin", "ssh://git@github.com/douhashi/soba.git")
+			},
+			wantRepo: "douhashi/soba",
 			wantErr:  false,
 		},
 		{


### PR DESCRIPTION
## 実装完了

fixes #136

### 変更内容
- `ParseRepositoryFromURL`関数を改修し、`ssh://git@github.com/owner/repo.git`形式のURLパースに対応
- ポート番号なしのSSH URLパターンを優先的に処理し、ポート番号付きのパターンとの競合を回避
- TDDアプローチで実装（テストファースト → 実装 → リファクタリング）

### 対応したURLフォーマット
新規対応:
- `ssh://git@github.com/owner/repo.git`
- `ssh://git@github.com/owner/repo`

既存サポート（継続）:
- `https://github.com/owner/repo.git`
- `git@github.com:owner/repo.git`
- `ssh://git@github.com:22/owner/repo.git`

### テスト結果
- 単体テスト: ✅ パス
  - 新規テストケース2つを追加
  - 既存テストケースの回帰テスト実施
- 統合テスト: ✅ パス
  - `soba init`でSSH URLを使った初期化テストを追加
- 全体テスト: ✅ パス（`make test`）

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] TDDサイクルの実践（Red → Green → Refactor）