### PR TITLE
feat: templateに claude/commands/soba を埋め込む (#142)

### DIFF
--- a/internal/config/claude_commands_manager.go
+++ b/internal/config/claude_commands_manager.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// ClaudeCommandsManager manages Claude command templates using embedded file system
+type ClaudeCommandsManager struct {
+	embedFS  embed.FS
+	rootPath string
+}
+
+// NewClaudeCommandsManager creates a new ClaudeCommandsManager
+func NewClaudeCommandsManager(embedFS embed.FS, rootPath string) *ClaudeCommandsManager {
+	return &ClaudeCommandsManager{
+		embedFS:  embedFS,
+		rootPath: rootPath,
+	}
+}
+
+// ListTemplates returns a sorted list of template file names
+func (m *ClaudeCommandsManager) ListTemplates() ([]string, error) {
+	var templates []string
+
+	err := fs.WalkDir(m.embedFS, m.rootPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			// Get relative path from root
+			relPath, err := filepath.Rel(m.rootPath, path)
+			if err != nil {
+				return err
+			}
+			templates = append(templates, relPath)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list templates: %w", err)
+	}
+
+	sort.Strings(templates)
+	return templates, nil
+}
+
+// GetTemplate returns an io.Reader for the specified template file
+func (m *ClaudeCommandsManager) GetTemplate(filename string) (io.Reader, error) {
+	return m.readFile(filename)
+}
+
+// CopyTemplates copies all template files to the target directory
+func (m *ClaudeCommandsManager) CopyTemplates(targetDir string) error {
+	// Create target directory if it doesn't exist
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("failed to create target directory: %w", err)
+	}
+
+	// List all templates
+	templates, err := m.ListTemplates()
+	if err != nil {
+		return err
+	}
+
+	// Copy each template
+	for _, tmpl := range templates {
+		targetPath := filepath.Join(targetDir, tmpl)
+
+		// Check if target file already exists
+		if _, err := os.Stat(targetPath); err == nil {
+			// File exists, skip
+			continue
+		}
+
+		// Read source file
+		reader, err := m.readFile(tmpl)
+		if err != nil {
+			// Skip files that can't be read
+			continue
+		}
+
+		// Create target file
+		targetFile, err := os.Create(targetPath)
+		if err != nil {
+			return fmt.Errorf("failed to create file %s: %w", targetPath, err)
+		}
+		defer targetFile.Close()
+
+		// Copy content
+		if _, err := io.Copy(targetFile, reader); err != nil {
+			return fmt.Errorf("failed to copy content to %s: %w", targetPath, err)
+		}
+
+		// Set permissions
+		if err := targetFile.Chmod(0644); err != nil {
+			return fmt.Errorf("failed to set permissions for %s: %w", targetPath, err)
+		}
+	}
+
+	return nil
+}
+
+// ValidateTemplates checks if the embedded templates are accessible
+func (m *ClaudeCommandsManager) ValidateTemplates() error {
+	templates, err := m.ListTemplates()
+	if err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	if len(templates) == 0 {
+		return fmt.Errorf("no templates found in %s", m.rootPath)
+	}
+
+	return nil
+}
+
+// readFile reads a file from the embedded file system
+func (m *ClaudeCommandsManager) readFile(filename string) (io.Reader, error) {
+	fullPath := filepath.Join(m.rootPath, filename)
+	file, err := m.embedFS.Open(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", filename, err)
+	}
+	return file, nil
+}

--- a/internal/config/claude_commands_manager_test.go
+++ b/internal/config/claude_commands_manager_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"embed"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+//go:embed testdata/claude/commands/soba/*
+var testClaudeCommandsFS embed.FS
+
+func TestClaudeCommandsManager_ListTemplates(t *testing.T) {
+	manager := &ClaudeCommandsManager{
+		embedFS:  testClaudeCommandsFS,
+		rootPath: "testdata/claude/commands/soba",
+	}
+
+	templates, err := manager.ListTemplates()
+	if err != nil {
+		t.Fatalf("Failed to list templates: %v", err)
+	}
+
+	expected := []string{"test1.md", "test2.md"}
+	if len(templates) != len(expected) {
+		t.Errorf("Expected %d templates, got %d", len(expected), len(templates))
+	}
+
+	for i, tmpl := range expected {
+		if i >= len(templates) || templates[i] != tmpl {
+			t.Errorf("Expected template[%d] to be %s, got %s", i, tmpl, templates[i])
+		}
+	}
+}
+
+func TestClaudeCommandsManager_GetTemplate(t *testing.T) {
+	manager := &ClaudeCommandsManager{
+		embedFS:  testClaudeCommandsFS,
+		rootPath: "testdata/claude/commands/soba",
+	}
+
+	tests := []struct {
+		name     string
+		filename string
+		wantErr  bool
+	}{
+		{
+			name:     "existing file",
+			filename: "test1.md",
+			wantErr:  false,
+		},
+		{
+			name:     "non-existing file",
+			filename: "nonexistent.md",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := manager.GetTemplate(tt.filename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetTemplate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && content == nil {
+				t.Error("Expected content reader, got nil")
+			}
+		})
+	}
+}
+
+func TestClaudeCommandsManager_CopyTemplates(t *testing.T) {
+	manager := &ClaudeCommandsManager{
+		embedFS:  testClaudeCommandsFS,
+		rootPath: "testdata/claude/commands/soba",
+	}
+
+	tmpDir := t.TempDir()
+	targetDir := filepath.Join(tmpDir, ".claude", "commands", "soba")
+
+	err := manager.CopyTemplates(targetDir)
+	if err != nil {
+		t.Fatalf("Failed to copy templates: %v", err)
+	}
+
+	// Check if files were copied
+	entries, err := os.ReadDir(targetDir)
+	if err != nil {
+		t.Fatalf("Failed to read target directory: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Errorf("Expected 2 files, got %d", len(entries))
+	}
+
+	// Test skipping existing files
+	err = manager.CopyTemplates(targetDir)
+	if err != nil {
+		t.Errorf("Should not fail when files already exist: %v", err)
+	}
+}
+
+func TestClaudeCommandsManager_CopyTemplatesWithSkip(t *testing.T) {
+	manager := &ClaudeCommandsManager{
+		embedFS:  testClaudeCommandsFS,
+		rootPath: "testdata/claude/commands/soba",
+	}
+
+	tmpDir := t.TempDir()
+	targetDir := filepath.Join(tmpDir, ".claude", "commands", "soba")
+
+	// Create target directory and one existing file
+	os.MkdirAll(targetDir, 0755)
+	existingFile := filepath.Join(targetDir, "test1.md")
+	os.WriteFile(existingFile, []byte("existing content"), 0644)
+
+	err := manager.CopyTemplates(targetDir)
+	if err != nil {
+		t.Fatalf("Failed to copy templates: %v", err)
+	}
+
+	// Check that existing file was not overwritten
+	content, _ := os.ReadFile(existingFile)
+	if string(content) != "existing content" {
+		t.Error("Existing file was overwritten")
+	}
+
+	// Check that new file was created
+	newFile := filepath.Join(targetDir, "test2.md")
+	if _, err := os.Stat(newFile); os.IsNotExist(err) {
+		t.Error("New file was not created")
+	}
+}
+
+func TestClaudeCommandsManager_ValidateTemplates(t *testing.T) {
+	manager := &ClaudeCommandsManager{
+		embedFS:  testClaudeCommandsFS,
+		rootPath: "testdata/claude/commands/soba",
+	}
+
+	err := manager.ValidateTemplates()
+	if err != nil {
+		t.Errorf("ValidateTemplates() should not fail with valid templates: %v", err)
+	}
+
+	// Test with invalid embed path
+	invalidManager := &ClaudeCommandsManager{
+		embedFS:  testClaudeCommandsFS,
+		rootPath: "invalid/path",
+	}
+
+	err = invalidManager.ValidateTemplates()
+	if err == nil {
+		t.Error("ValidateTemplates() should fail with invalid path")
+	}
+}
+
+func TestClaudeCommandsManager_ReadFile(t *testing.T) {
+	manager := &ClaudeCommandsManager{
+		embedFS:  testClaudeCommandsFS,
+		rootPath: "testdata/claude/commands/soba",
+	}
+
+	// Test reading existing file
+	reader, err := manager.readFile("test1.md")
+	if err != nil {
+		t.Errorf("Failed to read existing file: %v", err)
+	}
+	if reader == nil {
+		t.Error("Expected reader, got nil")
+	}
+
+	// Test reading non-existing file
+	_, err = manager.readFile("nonexistent.md")
+	if err == nil {
+		t.Error("Expected error for non-existing file")
+	}
+}

--- a/internal/config/template_embed.go
+++ b/internal/config/template_embed.go
@@ -1,6 +1,17 @@
 package config
 
-import _ "embed"
+import (
+	"embed"
+	_ "embed"
+)
 
 //go:embed config_template.yml
 var configTemplateContent string
+
+//go:embed templates/claude/commands/soba/*
+var ClaudeCommandsFS embed.FS
+
+// GetClaudeCommandsManager returns a manager for Claude command templates
+func GetClaudeCommandsManager() *ClaudeCommandsManager {
+	return NewClaudeCommandsManager(ClaudeCommandsFS, "templates/claude/commands/soba")
+}

--- a/internal/config/templates/claude/commands/soba/implement.md
+++ b/internal/config/templates/claude/commands/soba/implement.md
@@ -1,0 +1,97 @@
+---
+allowed-tools: TodoRead, TodoWrite, Bash, Read, Write, Edit, MultiEdit, Grep, Glob
+description: "TDD implementation and PR creation"
+---
+
+## Overview
+
+Proceed with TDD development based on implementation plan and create Pull Request.
+
+---
+
+## Prerequisites
+
+- Implementation plan exists in Issue comments
+- Label is in `soba:doing` state
+
+---
+
+## Rules
+
+1. **Always check and follow the implementation plan**
+2. **Practice TDD (Test First)**
+3. **Respect existing design and architecture**
+4. **Create PR after implementation completion**
+5. **Passing all tests is a requirement**
+
+## Important Notes
+
+- Think hard and choose the best architecture with good maintainability. You don't need to respect existing implementations too much.
+- Maintaining compatibility is not required. Code complexity due to maintaining backward compatibility is more harmful.
+- Passing the full test suite is an **absolute requirement**. However, do not skip test code.
+
+---
+
+## Execution Steps
+
+1. **Check Issue and Plan**
+   - Check content with `gh issue view <number>`
+   - Check comments with `gh issue view <number> --comments`
+
+2. **Create Tests**
+   - Create test cases based on plan
+   - Red → Green → Refactor
+
+3. **Implementation**
+   - Commit in small units
+   - Meaningful commit messages
+
+4. **Run Tests**
+   ```bash
+   # Run tests (recommended)
+   make test
+   ```
+   - Run full test suite (required)
+
+5. **Create PR Template**
+   - Create `./.tmp/pull-request-<number>.md`
+
+6. **Create PR**
+   ```bash
+   gh pr create \
+     --title "feat: [feature name] (#<Issue number>)" \
+     --body-file ./.tmp/pull-request-<number>.md \
+     --base main
+   ```
+
+7. **Issue Comment**
+   - "Created PR #<number>"
+
+8. **Update Labels**
+   ```bash
+   gh issue edit <number> \
+     --remove-label "soba:doing" \
+     --add-label "soba:review-requested"
+   ```
+
+---
+
+## PR Template
+
+```markdown
+## Implementation Complete
+
+fixes #<number>
+
+### Changes
+- [Main changes]
+
+### Test Results
+- Unit tests: ✅ Pass
+- Full test suite: ✅ Pass
+
+### Checklist
+- [ ] Implementation follows the plan
+- [ ] Test coverage ensured
+- [ ] No impact on existing features
+```

--- a/internal/config/templates/claude/commands/soba/plan.md
+++ b/internal/config/templates/claude/commands/soba/plan.md
@@ -1,0 +1,98 @@
+---
+allowed-tools: TodoWrite, TodoRead, Bash, Read, Grep, Glob
+description: "Develop implementation plan for GitHub Issue"
+---
+
+## Overview
+
+Develop implementation plan for GitHub Issue and post it as an Issue comment.
+
+---
+
+## Prerequisites
+
+- Label is in `soba:planning` state
+
+---
+
+## Rules
+
+1. **Focus on planning without code modification**
+2. **Design plan based on TDD premise**
+3. **Follow existing architecture**
+4. **Break down into executable step units**
+5. **Create plan in template format**
+6. **Update label to `soba:ready` after completion**
+
+## Important Notes
+
+- Think hard and choose the best architecture with good maintainability. (You don't need to respect existing implementations too much)
+- Maintaining compatibility is not required (Code complexity due to maintaining backward compatibility is more harmful)
+
+---
+
+## Execution Steps
+
+1. **Check Issue**
+   - Check content with `gh issue view <number>`
+   - Check comments with `gh issue view <number> --comments`
+
+2. **Investigate Codebase**
+   - Check related files and past implementations
+   - Identify impact scope and dependencies
+
+3. **Technology Selection**
+   - Decide on libraries and patterns to use
+   - Clarify selection reasons
+
+4. **Define Implementation Steps**
+   - Break down into testable units
+   - Document related files and side effects
+
+5. **Develop Test, Risk, and Schedule Plans**
+   - Test plan (unit and integration)
+   - Risks and countermeasures
+   - Implementation timeframe estimates
+
+6. **Create Plan File**
+   - Save to `./.tmp/plan-[slug].md`
+
+7. **Post Comment**
+   - `gh issue comment <number> --body-file ./.tmp/plan-[slug].md`
+
+8. **Update Label**
+   - `gh issue edit <number> --remove-label "soba:planning" --add-label "soba:ready"`
+
+---
+
+## Template
+
+```markdown
+# Implementation Plan: [Title]
+
+## Requirements Overview
+- [Purpose and background]
+- [Functional requirements]
+- [Acceptance criteria]
+
+## Design Policy
+- [Technology selection and reasons]
+- [Architectural considerations]
+
+## Implementation Steps
+1. [Step name]
+   - Work content: [Details]
+   - Related files: [File path]
+
+## Test Plan
+- Unit tests: [Target and cases]
+- Integration tests: [Scenarios]
+
+## Risks and Countermeasures
+- Risk: [Content]
+  Countermeasure: [Method]
+
+## Schedule
+- Estimate: Total [X] hours
+- By step: Each [Y] hours
+```

--- a/internal/config/templates/claude/commands/soba/review.md
+++ b/internal/config/templates/claude/commands/soba/review.md
@@ -1,0 +1,91 @@
+---
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Grep, Glob, LS
+description: "Review a Pull Request for a soba Issue"
+---
+
+# Review PR
+
+Conduct PR review.
+
+## Context
+
+- Issue number: $ARGUMENTS
+
+## Workflow
+
+### 1. Check Issue
+
+```bash
+GH_PAGER= gh issue view <issue-number>
+GH_PAGER= gh issue view <issue-number> --comments
+```
+
+### 2. Check PR
+
+```bash
+GH_PAGER= gh pr view <PR-number>
+GH_PAGER= gh pr view <PR-number> --json mergeable,mergeStateStatus
+```
+
+### 3. Check Code Changes
+
+```bash
+GH_PAGER= gh pr diff <PR-number>
+```
+
+Review points:
+- Compliance with coding standards
+- Test implementation status
+- Security concerns
+- Presence of unnecessary diffs
+
+### 4. Check CI (Required - wait for completion)
+
+```bash
+gh pr checks <PR-number> --watch  # Timeout 600000
+```
+
+⚠️ **Important**: Do not post review results before CI completion
+
+### 5. Post Review Results
+
+Create `./.tmp/review-result-<issue-number>.md`:
+
+```markdown
+## Review Results
+
+- Issue: #<issue-number>
+- PR: #<PR-number>
+
+### ✅ Decision
+- [ ] Approve (LGTM)
+- [ ] Request changes
+
+### 🔄 Merge Status
+- [ ] No conflicts
+- [ ] Conflicts exist (rebase required)
+
+### 👍 Good Points
+- [Good aspects of implementation]
+
+### 🔧 Improvement Suggestions
+- [Specific improvement points]
+```
+
+Post:
+```bash
+gh pr comment <PR-number> --body "$(cat ./.tmp/review-result-<issue-number>.md)"
+```
+
+### 6. Update Labels
+
+For approval:
+```bash
+gh issue edit <issue-number> --remove-label "soba:reviewing" --add-label "soba:done"
+gh pr edit <PR-number> --add-label "soba:lgtm"
+```
+
+For change requests:
+```bash
+gh issue edit <issue-number> --remove-label "soba:reviewing" --add-label "soba:requires-changes"
+```

--- a/internal/config/templates/claude/commands/soba/revise.md
+++ b/internal/config/templates/claude/commands/soba/revise.md
@@ -1,0 +1,83 @@
+---
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Grep, Glob, LS
+description: "Revise implementation based on review feedback"
+---
+
+# Revise PR
+
+Address review feedback and comments.
+
+## Context
+
+- Issue number: $ARGUMENTS
+
+## Important Notes
+
+- Think hard and choose the best architecture with good maintainability. You don't need to respect existing implementations too much.
+- Maintaining compatibility is not required. Code complexity due to maintaining backward compatibility is more harmful.
+- Passing the full test suite is an **absolute requirement**. However, do not skip test code.
+
+## Workflow
+
+### 1. Check PR
+
+```bash
+GH_PAGER= gh pr list --search "linked:$ARGUMENTS" --state open --json number --jq '.[0].number'
+```
+
+### 2. Check Review Comments
+
+```bash
+GH_PAGER= gh pr view <PR-number> --comments
+```
+
+### 3. Address Review Comments
+
+Implement fixes based on review comments:
+- Improve code quality
+- Add/modify tests
+- Improve error handling
+- Remove unnecessary diffs
+
+### 4. Run Tests
+
+```bash
+# Run tests (recommended)
+make test  # Timeout 600000
+```
+
+### 5. Commit Changes
+
+```bash
+git add -A
+git commit -m "fix: Address review feedback
+
+- [Summary of changes]
+"
+git push
+```
+
+### 6. Post Completion Comment
+
+Create `./.tmp/revise-complete-<issue-number>.md`:
+
+```markdown
+## Review Feedback Addressed
+
+The following feedback has been addressed:
+- ✅ [Addressed item]
+
+All tests have been confirmed to pass.
+Please review again.
+```
+
+Post:
+```bash
+gh pr comment <PR-number> --body "$(cat ./.tmp/revise-complete-<issue-number>.md)"
+```
+
+### 7. Update Labels
+
+```bash
+gh issue edit <issue-number> --remove-label "soba:revising" --add-label "soba:review-requested"
+```

--- a/internal/config/testdata/claude/commands/soba/test1.md
+++ b/internal/config/testdata/claude/commands/soba/test1.md
@@ -1,0 +1,3 @@
+# Test Template 1
+
+This is a test template file for unit testing.

--- a/internal/config/testdata/claude/commands/soba/test2.md
+++ b/internal/config/testdata/claude/commands/soba/test2.md
@@ -1,0 +1,3 @@
+# Test Template 2
+
+This is another test template file for unit testing.


### PR DESCRIPTION
## Implementation Complete

fixes #142

### Changes
- ClaudeCommandsManagerクラスを新規作成し、embed.FSを使用したテンプレート管理機能を実装
- template_embed.goにClaude commandsテンプレートの埋め込み設定を追加
- init.goをリファクタリングし、ファイルシステムからの直接コピーから埋め込みテンプレートベースの実装に変更
- 不要になったcopyFile関数を削除
- バイナリ配布時でもテンプレートが正しくコピーされることを保証

### Test Results
- Unit tests: ✅ Pass
- Full test suite: ✅ Pass

### Implementation Details

#### ClaudeCommandsManager
- `embed.FS`を使用してテンプレートファイルをバイナリに埋め込み
- 既存ファイルのスキップ機能を維持
- ディレクトリ構造を保持したままのコピー機能

#### テスト戦略
- ClaudeCommandsManagerの単体テストを作成
- init_test.goのテストケースを埋め込みベースに更新
- init_integration_test.goのテストも同様に更新

### Checklist
- [x] Implementation follows the plan
- [x] Test coverage ensured
- [x] No impact on existing features
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)