### PR TITLE
fix: Slackテンプレートを埋め込みに変更してバイナリ配布時の問題を修正

### DIFF
--- a/internal/config/template_embed.go
+++ b/internal/config/template_embed.go
@@ -11,6 +11,14 @@ var configTemplateContent string
 //go:embed templates/claude/commands/soba/*
 var ClaudeCommandsFS embed.FS
 
+//go:embed templates/slack/*.json
+var SlackTemplatesFS embed.FS
+
+// GetSlackTemplatesFS returns the embedded Slack templates filesystem
+func GetSlackTemplatesFS() embed.FS {
+	return SlackTemplatesFS
+}
+
 // GetClaudeCommandsManager returns a manager for Claude command templates
 func GetClaudeCommandsManager() *ClaudeCommandsManager {
 	return NewClaudeCommandsManager(ClaudeCommandsFS, "templates/claude/commands/soba")

--- a/internal/config/templates/slack/error.json
+++ b/internal/config/templates/slack/error.json
@@ -1,0 +1,28 @@
+{
+    "blocks": [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "❌ Error: {{.Title}}",
+                "emoji": true
+            }
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Error Details:*\n```{{.ErrorMessage}}```"
+            }
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": "⚠️ This error requires attention"
+                }
+            ]
+        }
+    ]
+}

--- a/internal/config/templates/slack/notify.json
+++ b/internal/config/templates/slack/notify.json
@@ -1,0 +1,11 @@
+{
+    "blocks": [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "{{.Text}}"
+            }
+        }
+    ]
+}

--- a/internal/config/templates/slack/phase_start.json
+++ b/internal/config/templates/slack/phase_start.json
@@ -1,0 +1,30 @@
+{
+    "blocks": [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "Phase: {{.Phase}} #{{.IssueNumber}}",
+                "emoji": true
+            }
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*{{.Phase}}* phase started for *{{.Repository}}* *#{{.IssueNumber}}*"
+            },
+            "accessory": {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Open Issue",
+                    "emoji": true
+                },
+                "value": "open_issue_button_{{.IssueNumber}}",
+                "url": "{{.IssueURL}}",
+                "action_id": "button-action"
+            }
+        }
+    ]
+}

--- a/internal/config/templates/slack/pr_merged.json
+++ b/internal/config/templates/slack/pr_merged.json
@@ -1,0 +1,46 @@
+{
+    "blocks": [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "✅ PR #{{.PRNumber}} Merged",
+                "emoji": true
+            }
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*PR #{{.PRNumber}}* has been merged successfully.\nRelated to issue *#{{.IssueNumber}}*"
+            }
+        },
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "View PR",
+                        "emoji": true
+                    },
+                    "value": "view_pr_{{.PRNumber}}",
+                    "url": "{{.PRURL}}",
+                    "action_id": "view-pr-action"
+                },
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "View Issue",
+                        "emoji": true
+                    },
+                    "value": "view_issue_{{.IssueNumber}}",
+                    "url": "{{.IssueURL}}",
+                    "action_id": "view-issue-action"
+                }
+            ]
+        }
+    ]
+}

--- a/internal/infra/slack/template_manager_test.go
+++ b/internal/infra/slack/template_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/douhashi/soba/internal/config"
 	"github.com/douhashi/soba/pkg/logging"
 )
 
@@ -163,4 +164,136 @@ func TestTemplateManager_LoadTemplates_MissingDirectory(t *testing.T) {
 	// Test loading templates from non-existent directory
 	err = tm.LoadTemplates()
 	assert.Error(t, err)
+}
+
+func TestTemplateManagerWithFS_LoadTemplates(t *testing.T) {
+	logger := logging.NewMockLogger()
+
+	// Test with actual embedded templates from config package
+	tm := NewTemplateManagerWithFS(logger, config.GetSlackTemplatesFS())
+
+	// Test loading embedded templates
+	err := tm.LoadTemplates()
+	assert.NoError(t, err, "Should load embedded templates successfully")
+}
+
+func TestTemplateManagerWithFS_RenderTemplate(t *testing.T) {
+	logger := logging.NewMockLogger()
+
+	// Use the real embedded FS from config package
+	tm := NewTemplateManagerWithFS(logger, config.GetSlackTemplatesFS())
+
+	// Load templates
+	err := tm.LoadTemplates()
+	require.NoError(t, err)
+
+	// Test rendering different template types
+	t.Run("Render notify template", func(t *testing.T) {
+		data := NotifyData{Text: "Test notification"}
+		result, err := tm.RenderTemplate("notify", data)
+		assert.NoError(t, err)
+
+		// Verify the result is valid JSON
+		var blockMsg BlockMessage
+		err = json.Unmarshal(result, &blockMsg)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, blockMsg.Blocks)
+	})
+
+	t.Run("Render phase_start template", func(t *testing.T) {
+		data := PhaseStartData{
+			Phase:       "plan",
+			IssueNumber: 123,
+			IssueURL:    "https://github.com/test/repo/issues/123",
+			Repository:  "test/repo",
+		}
+		result, err := tm.RenderTemplate("phase_start", data)
+		assert.NoError(t, err)
+
+		// Verify the result is valid JSON
+		var blockMsg BlockMessage
+		err = json.Unmarshal(result, &blockMsg)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, blockMsg.Blocks)
+	})
+
+	t.Run("Render pr_merged template", func(t *testing.T) {
+		data := PRMergedData{
+			PRNumber:    456,
+			IssueNumber: 123,
+			PRURL:       "https://github.com/test/repo/pull/456",
+			IssueURL:    "https://github.com/test/repo/issues/123",
+		}
+		result, err := tm.RenderTemplate("pr_merged", data)
+		assert.NoError(t, err)
+
+		// Verify the result is valid JSON
+		var blockMsg BlockMessage
+		err = json.Unmarshal(result, &blockMsg)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, blockMsg.Blocks)
+	})
+
+	t.Run("Render error template", func(t *testing.T) {
+		data := ErrorData{
+			Title:        "Test Error",
+			ErrorMessage: "Something went wrong",
+		}
+		result, err := tm.RenderTemplate("error", data)
+		assert.NoError(t, err)
+
+		// Verify the result is valid JSON
+		var blockMsg BlockMessage
+		err = json.Unmarshal(result, &blockMsg)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, blockMsg.Blocks)
+	})
+}
+
+func TestTemplateManagerWithFS_FallbackToFilesystem(t *testing.T) {
+	logger := logging.NewMockLogger()
+
+	// Create temporary template directory for testing
+	tempDir := t.TempDir()
+	templateDir := filepath.Join(tempDir, "templates", "slack")
+	err := os.MkdirAll(templateDir, 0755)
+	require.NoError(t, err)
+
+	// Create test template file
+	templateContent := `{
+		"blocks": [
+			{
+				"type": "section",
+				"text": {
+					"type": "mrkdwn",
+					"text": "{{.Text}}"
+				}
+			}
+		]
+	}`
+	writeErr := os.WriteFile(filepath.Join(templateDir, "notify.json"), []byte(templateContent), 0644)
+	require.NoError(t, writeErr)
+
+	// Change working directory to temp dir for testing
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(oldDir)
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	// Test filesystem template manager (fallback mode)
+	tm := NewTemplateManager(logger)
+	err = tm.LoadTemplates()
+	assert.NoError(t, err)
+
+	// Test rendering
+	data := NotifyData{Text: "Filesystem template test"}
+	result, err := tm.RenderTemplate("notify", data)
+	assert.NoError(t, err)
+
+	// Verify the result is valid JSON
+	var blockMsg BlockMessage
+	err = json.Unmarshal(result, &blockMsg)
+	assert.NoError(t, err)
+	assert.Len(t, blockMsg.Blocks, 1)
 }


### PR DESCRIPTION
## Summary
- リリースバイナリでSlack通知が動作しない問題を修正
- テンプレートファイルをgo:embedでバイナリに埋め込むように変更
- 埋め込みテンプレートの読み込みテストを追加

## Problem
リリースされたバイナリでは`templates/slack`ディレクトリが存在しないため、Slackテンプレートが読み込めず、NoOpManagerにフォールバックしてSlack通知が送信されていませんでした。

## Solution
1. **テンプレートファイルの埋め込み**
   - `internal/config/templates/slack/`にテンプレートファイルをコピー
   - `template_embed.go`に`SlackTemplatesFS`を追加

2. **TemplateManagerの改善**
   - `NewTemplateManagerWithFS`関数を追加して埋め込みFS対応
   - 埋め込みファイルを優先、ファイルシステムにフォールバック

3. **テストの追加**
   - 埋め込みテンプレートの読み込みテスト
   - 各テンプレートのレンダリングテスト

## Test plan
- [x] `make test`で全テストがパス
- [x] ビルドしたバイナリでSlack通知が動作することを確認
- [x] golangci-lintでエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)