### PR TITLE
feat: PRマージ後にbase branchを自動更新する機能を追加

### DIFF
--- a/internal/config/config_template.yml
+++ b/internal/config/config_template.yml
@@ -39,6 +39,8 @@ slack:
 git:
   # Base path for git worktrees
   worktree_base_path: .git/soba/worktrees
+  # Base branch for rebase operations and worktree creation (default: main)
+  base_branch: main
 
 # Logging settings
 log:

--- a/internal/service/builder/dependency_resolver.go
+++ b/internal/service/builder/dependency_resolver.go
@@ -174,6 +174,7 @@ func (r *DependencyResolver) ResolveServices(ctx context.Context, clients *Resol
 	r.logger.Debug(ctx, "Creating PR watcher")
 	services.PRWatcher = serviceFactory.CreatePRWatcher(
 		clients.GitHubClient,
+		clients.GitClient,
 		r.config,
 	)
 

--- a/internal/service/builder/service_factory.go
+++ b/internal/service/builder/service_factory.go
@@ -15,7 +15,7 @@ type ServiceFactory interface {
 	CreateIssueProcessor(githubClient GitHubClientInterface, executor WorkflowExecutor) IssueProcessorInterface
 	CreateIssueWatcher(githubClient GitHubClientInterface, cfg *config.Config) IssueWatcher
 	CreateQueueManager(githubClient GitHubClientInterface, owner, repo string) interface{}
-	CreatePRWatcher(githubClient GitHubClientInterface, cfg *config.Config) PRWatcher
+	CreatePRWatcher(githubClient GitHubClientInterface, gitClient interface{}, cfg *config.Config) PRWatcher
 	CreateClosedIssueCleanupService(githubClient GitHubClientInterface, tmuxClient tmux.TmuxClient, owner, repo, sessionName string, enabled bool, interval time.Duration) ClosedIssueCleanupService
 	CreateDaemonServiceWithDependencies(workDir string, processor IssueProcessorInterface, watcher IssueWatcher, prWatcher PRWatcher, cleanupService ClosedIssueCleanupService, tmuxClient tmux.TmuxClient) DaemonService
 	CreateStatusService() StatusService

--- a/internal/service/daemon_test.go
+++ b/internal/service/daemon_test.go
@@ -398,7 +398,7 @@ func TestDaemonService_ConfigureAndStartWatchers_WithNilClosedIssueCleanupServic
 
 			// IssueWatcherとPRWatcherを作成
 			watcher := NewIssueWatcher(mockGitHubClient, cfg)
-			prWatcher := NewPRWatcher(mockGitHubClient, cfg)
+			prWatcher := NewPRWatcher(mockGitHubClient, NewMockGitClient(), cfg)
 
 			// ロガーを設定（nilポインタエラーを防ぐため）
 			if watcher != nil {
@@ -817,7 +817,7 @@ func TestDaemonService_ClosedIssueCleanupServiceLogger(t *testing.T) {
 
 			// Create IssueWatcher and PRWatcher
 			watcher := NewIssueWatcher(mockGitHubClient, tt.cfg)
-			prWatcher := NewPRWatcher(mockGitHubClient, tt.cfg)
+			prWatcher := NewPRWatcher(mockGitHubClient, NewMockGitClient(), tt.cfg)
 
 			if watcher != nil {
 				watcher.logger = mockLogger
@@ -928,7 +928,7 @@ func TestDaemonService_ClosedIssueCleanupServiceStartupLog(t *testing.T) {
 
 			// Create IssueWatcher and PRWatcher
 			watcher := NewIssueWatcher(mockGitHubClient, tt.cfg)
-			prWatcher := NewPRWatcher(mockGitHubClient, tt.cfg)
+			prWatcher := NewPRWatcher(mockGitHubClient, NewMockGitClient(), tt.cfg)
 
 			if watcher != nil {
 				watcher.logger = mockLogger

--- a/internal/service/default_service_factory.go
+++ b/internal/service/default_service_factory.go
@@ -91,12 +91,18 @@ func (f *DefaultServiceFactory) CreateQueueManager(githubClient builder.GitHubCl
 }
 
 // CreatePRWatcher creates PR watcher
-func (f *DefaultServiceFactory) CreatePRWatcher(githubClient builder.GitHubClientInterface, cfg *config.Config) builder.PRWatcher {
+func (f *DefaultServiceFactory) CreatePRWatcher(githubClient builder.GitHubClientInterface, gitClient interface{}, cfg *config.Config) builder.PRWatcher {
 	var concreteGithubClient GitHubClientInterface
 	if impl, ok := githubClient.(GitHubClientInterface); ok {
 		concreteGithubClient = impl
 	}
-	return &PRWatcherAdapter{NewPRWatcher(concreteGithubClient, cfg)}
+
+	var concreteGitClient GitClient
+	if gc, ok := gitClient.(*git.Client); ok {
+		concreteGitClient = gc
+	}
+
+	return &PRWatcherAdapter{NewPRWatcher(concreteGithubClient, concreteGitClient, cfg)}
 }
 
 // CreateClosedIssueCleanupService creates cleanup service

--- a/internal/service/mock_git_workspace.go
+++ b/internal/service/mock_git_workspace.go
@@ -18,3 +18,31 @@ func (m *MockGitWorkspaceManager) PrepareWorkspace(issueNumber int) error {
 func (m *MockGitWorkspaceManager) CleanupWorkspace(issueNumber int) error {
 	return nil
 }
+
+// MockGitClient はGitClientのモック実装
+type MockGitClient struct{}
+
+// NewMockGitClient は新しいMockGitClientを作成する
+func NewMockGitClient() GitClient {
+	return &MockGitClient{}
+}
+
+// CreateWorktree は成功を返す（モック実装）
+func (m *MockGitClient) CreateWorktree(worktreePath, branchName, baseBranch string) error {
+	return nil
+}
+
+// RemoveWorktree は成功を返す（モック実装）
+func (m *MockGitClient) RemoveWorktree(worktreePath string) error {
+	return nil
+}
+
+// UpdateBaseBranch は成功を返す（モック実装）
+func (m *MockGitClient) UpdateBaseBranch(branch string) error {
+	return nil
+}
+
+// WorktreeExists は常にfalseを返す（モック実装）
+func (m *MockGitClient) WorktreeExists(worktreePath string) bool {
+	return false
+}

--- a/internal/service/pr_watcher.go
+++ b/internal/service/pr_watcher.go
@@ -15,14 +15,15 @@ import (
 
 // PRWatcher はPR監視機能を提供する
 type PRWatcher struct {
-	client   GitHubClientInterface
-	config   *config.Config
-	interval time.Duration
-	logger   logging.Logger
+	client    GitHubClientInterface
+	gitClient GitClient
+	config    *config.Config
+	interval  time.Duration
+	logger    logging.Logger
 }
 
 // NewPRWatcher は新しいPRWatcherを作成する
-func NewPRWatcher(client GitHubClientInterface, cfg *config.Config) *PRWatcher {
+func NewPRWatcher(client GitHubClientInterface, gitClient GitClient, cfg *config.Config) *PRWatcher {
 	// デフォルト値の設定
 	if cfg.Workflow.Interval == 0 {
 		cfg.Workflow.Interval = 20
@@ -32,10 +33,11 @@ func NewPRWatcher(client GitHubClientInterface, cfg *config.Config) *PRWatcher {
 	log := logging.NewMockLogger() // デフォルトでMockLogger使用
 
 	return &PRWatcher{
-		client:   client,
-		config:   cfg,
-		interval: time.Duration(cfg.Workflow.Interval) * time.Second,
-		logger:   log,
+		client:    client,
+		gitClient: gitClient,
+		config:    cfg,
+		interval:  time.Duration(cfg.Workflow.Interval) * time.Second,
+		logger:    log,
 	}
 }
 
@@ -210,6 +212,27 @@ func (w *PRWatcher) mergePullRequest(ctx context.Context, pr github.PullRequest)
 			logging.Field{Key: "number", Value: pr.Number},
 			logging.Field{Key: "sha", Value: resp.SHA},
 		)
+
+		// マージ後にbase branchを最新に更新
+		if w.gitClient != nil {
+			w.logger.Info(ctx, "Updating base branch after PR merge",
+				logging.Field{Key: "branch", Value: w.config.Git.BaseBranch},
+				logging.Field{Key: "pr_number", Value: pr.Number},
+			)
+
+			if err := w.gitClient.UpdateBaseBranch(w.config.Git.BaseBranch); err != nil {
+				w.logger.Error(ctx, "Failed to update base branch after PR merge",
+					logging.Field{Key: "branch", Value: w.config.Git.BaseBranch},
+					logging.Field{Key: "pr_number", Value: pr.Number},
+					logging.Field{Key: "error", Value: err.Error()},
+				)
+			} else {
+				w.logger.Info(ctx, "Successfully updated base branch after PR merge",
+					logging.Field{Key: "branch", Value: w.config.Git.BaseBranch},
+					logging.Field{Key: "pr_number", Value: pr.Number},
+				)
+			}
+		}
 
 		// Slack通知: PRマージ完了
 		// PR番号からIssue番号を抽出 (ファイル名パターンから推測)

--- a/internal/service/pr_watcher_test.go
+++ b/internal/service/pr_watcher_test.go
@@ -90,7 +90,7 @@ func TestNewPRWatcher(t *testing.T) {
 		}
 		client := &MockGitHubClientForPR{}
 
-		watcher := NewPRWatcher(client, cfg)
+		watcher := NewPRWatcher(client, NewMockGitClient(), cfg)
 		require.NotNil(t, watcher)
 		assert.Equal(t, 30*time.Second, watcher.interval)
 		assert.NotNil(t, watcher.logger)
@@ -107,7 +107,7 @@ func TestNewPRWatcher(t *testing.T) {
 		}
 		client := &MockGitHubClientForPR{}
 
-		watcher := NewPRWatcher(client, cfg)
+		watcher := NewPRWatcher(client, NewMockGitClient(), cfg)
 		assert.Equal(t, 20*time.Second, watcher.interval)
 	})
 }
@@ -153,7 +153,7 @@ func TestWatchOnce(t *testing.T) {
 			},
 		}
 
-		watcher := NewPRWatcher(mockClient, cfg)
+		watcher := NewPRWatcher(mockClient, NewMockGitClient(), cfg)
 		watcher.SetLogger(logging.NewMockLogger())
 
 		ctx := context.Background()
@@ -207,7 +207,7 @@ func TestWatchOnce(t *testing.T) {
 			},
 		}
 
-		watcher := NewPRWatcher(mockClient, cfg)
+		watcher := NewPRWatcher(mockClient, NewMockGitClient(), cfg)
 		watcher.SetLogger(logging.NewMockLogger())
 
 		ctx := context.Background()
@@ -250,7 +250,7 @@ func TestWatchOnce(t *testing.T) {
 			},
 		}
 
-		watcher := NewPRWatcher(mockClient, cfg)
+		watcher := NewPRWatcher(mockClient, NewMockGitClient(), cfg)
 		watcher.SetLogger(logging.NewMockLogger())
 
 		ctx := context.Background()
@@ -288,7 +288,7 @@ func TestWatchOnce(t *testing.T) {
 			mergeError: &github.ErrorResponse{Message: "Merge failed"},
 		}
 
-		watcher := NewPRWatcher(mockClient, cfg)
+		watcher := NewPRWatcher(mockClient, NewMockGitClient(), cfg)
 		watcher.SetLogger(logging.NewMockLogger())
 
 		ctx := context.Background()
@@ -305,7 +305,7 @@ func TestParseRepository(t *testing.T) {
 				Repository: "owner/repo",
 			},
 		}
-		watcher := NewPRWatcher(&MockGitHubClientForPR{}, cfg)
+		watcher := NewPRWatcher(&MockGitHubClientForPR{}, NewMockGitClient(), cfg)
 
 		owner, repo := watcher.parseRepository()
 		assert.Equal(t, "owner", owner)
@@ -318,7 +318,7 @@ func TestParseRepository(t *testing.T) {
 				Repository: "invalid-format",
 			},
 		}
-		watcher := NewPRWatcher(&MockGitHubClientForPR{}, cfg)
+		watcher := NewPRWatcher(&MockGitHubClientForPR{}, NewMockGitClient(), cfg)
 		watcher.SetLogger(logging.NewMockLogger())
 
 		owner, repo := watcher.parseRepository()
@@ -352,7 +352,7 @@ func TestPRWatcher_WatchCycleLogs(t *testing.T) {
 			},
 		}
 
-		watcher := NewPRWatcher(mockClient, cfg)
+		watcher := NewPRWatcher(mockClient, NewMockGitClient(), cfg)
 		mockLogger := logging.NewMockLogger()
 		watcher.SetLogger(mockLogger)
 

--- a/templates/config/config.yml.tmpl
+++ b/templates/config/config.yml.tmpl
@@ -39,6 +39,8 @@ slack:
 git:
   # Base path for git worktrees
   worktree_base_path: .git/soba/worktrees
+  # Base branch for rebase operations and worktree creation (default: main)
+  base_branch: main
 
 # Logging settings
 log:


### PR DESCRIPTION
## Summary
- PRマージ成功後に、設定値 `base_branch` で指定されたローカルブランチを最新に更新する機能を追加
- phase開始時（worktree作成前）の既存のブランチ更新と合わせて、不必要なconflictを防ぐ

## Changes
- `PRWatcher` にGitClientを追加し、マージ後に `UpdateBaseBranch()` を呼び出す
- `ServiceFactory` と `DependencyResolver` をGitClient引数追加で更新  
- テスト用の `MockGitClient` を追加
- 全テストファイルで `NewPRWatcher` 呼び出しを更新

## Test plan
- [x] コンパイル成功
- [x] 既存テスト通過
- [ ] PRマージ時にbase branchが更新されることを手動確認

🤖 Generated with [Claude Code](https://claude.ai/code)