### PR TITLE
fix: soba init時にsoba:lgtmラベルが作成されない問題を修正 (#147)

### DIFF
--- a/internal/infra/github/labels.go
+++ b/internal/infra/github/labels.go
@@ -266,5 +266,10 @@ func GetSobaLabels() []CreateLabelRequest {
 			Color:       "ff6347",
 			Description: "Claude applying requested changes",
 		},
+		{
+			Name:        "soba:lgtm",
+			Color:       "0e8a16",
+			Description: "Review approved, target for auto merge",
+		},
 	}
 }

--- a/internal/infra/github/labels_test.go
+++ b/internal/infra/github/labels_test.go
@@ -240,8 +240,8 @@ func TestClient_ListLabels(t *testing.T) {
 func TestGetSobaLabels(t *testing.T) {
 	labels := GetSobaLabels()
 
-	// 10個のラベルが定義されていることを確認
-	assert.Len(t, labels, 10)
+	// 11個のラベルが定義されていることを確認
+	assert.Len(t, labels, 11)
 
 	// 各ラベルの内容を検証
 	expectedLabels := map[string]struct {
@@ -258,6 +258,7 @@ func TestGetSobaLabels(t *testing.T) {
 		"soba:done":             {"0e8a16", "Review approved, ready to merge"},
 		"soba:requires-changes": {"d93f0b", "Review requested modifications"},
 		"soba:revising":         {"ff6347", "Claude applying requested changes"},
+		"soba:lgtm":             {"0e8a16", "Review approved, target for auto merge"},
 	}
 
 	for _, label := range labels {


### PR DESCRIPTION
## Implementation Complete

fixes #147

### Changes
- GetSobaLabels関数に`soba:lgtm`ラベル定義を追加
- ラベル数を10から11に変更
- テストケースを更新して`soba:lgtm`ラベルの検証を追加

### Test Results
- Unit tests: ✅ Pass
- Full test suite: ✅ Pass

### Checklist
- [x] Implementation follows the plan
- [x] Test coverage ensured
- [x] No impact on existing features

### 詳細
`soba:lgtm`ラベルは定数として定義されPRマージ機能で使用されていましたが、`GetSobaLabels()`関数から漏れていたため、`soba init`実行時に作成されない問題がありました。

本修正により、`soba init`実行時に他のラベルと同様に`soba:lgtm`ラベルが自動作成されるようになります。