### PR TITLE
feat: worktreeを作成するディレクトリを変更 (#154)

### DIFF
--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -44,7 +44,7 @@ func TestRunConfig_Success(t *testing.T) {
 			NotificationsEnabled: false,
 		},
 		Git: config.GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 		},
 		Phase: config.PhaseConfig{
 			Plan: config.PhaseCommand{
@@ -109,7 +109,7 @@ log:
 	assert.NotNil(t, cfg)
 	// Verify defaults are set
 	assert.Equal(t, 20, cfg.Workflow.Interval)
-	assert.Equal(t, ".git/soba/worktrees", cfg.Git.WorktreeBasePath)
+	assert.Equal(t, "/tmp/soba/worktrees", cfg.Git.WorktreeBasePath)
 }
 
 func TestRunConfig_InvalidYAML(t *testing.T) {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -185,7 +185,7 @@ func TestInitCommand(t *testing.T) {
 		assert.Equal(t, "test-owner/test-repo", loadedConfig.GitHub.Repository)
 		assert.Equal(t, 20, loadedConfig.Workflow.Interval)
 		assert.True(t, loadedConfig.Workflow.UseTmux)
-		assert.Equal(t, ".git/soba/worktrees", loadedConfig.Git.WorktreeBasePath)
+		assert.Equal(t, "/tmp/soba/worktrees", loadedConfig.Git.WorktreeBasePath)
 	})
 
 	t.Run("should create GitHub labels when config has repository info", func(t *testing.T) {

--- a/internal/config/config_template.yml
+++ b/internal/config/config_template.yml
@@ -37,8 +37,8 @@ slack:
 
 # Git settings
 git:
-  # Base path for git worktrees
-  worktree_base_path: .git/soba/worktrees
+  # Base path for git worktrees (default: /tmp/soba/worktrees)
+  worktree_base_path: /tmp/soba/worktrees
   # Base branch for rebase operations and worktree creation (default: main)
   base_branch: main
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -157,8 +157,8 @@ github:
 		t.Errorf("Default tmux command delay = %v, want 3", cfg.Workflow.TmuxCommandDelay)
 	}
 
-	if cfg.Git.WorktreeBasePath != ".git/soba/worktrees" {
-		t.Errorf("Default git worktree base path = %v, want .git/soba/worktrees", cfg.Git.WorktreeBasePath)
+	if cfg.Git.WorktreeBasePath != "/tmp/soba/worktrees" {
+		t.Errorf("Default git worktree base path = %v, want /tmp/soba/worktrees", cfg.Git.WorktreeBasePath)
 	}
 }
 
@@ -175,8 +175,8 @@ func TestLoadConfigFileNotFound(t *testing.T) {
 	if cfg != nil && cfg.Workflow.Interval != 20 {
 		t.Errorf("Default workflow interval = %v, want 20", cfg.Workflow.Interval)
 	}
-	if cfg != nil && cfg.Git.WorktreeBasePath != ".git/soba/worktrees" {
-		t.Errorf("Default git worktree base path = %v, want .git/soba/worktrees", cfg.Git.WorktreeBasePath)
+	if cfg != nil && cfg.Git.WorktreeBasePath != "/tmp/soba/worktrees" {
+		t.Errorf("Default git worktree base path = %v, want /tmp/soba/worktrees", cfg.Git.WorktreeBasePath)
 	}
 	expectedLogPath := fmt.Sprintf(".soba/logs/soba-%d.log", os.Getpid())
 	if cfg != nil && cfg.Log.OutputPath != expectedLogPath {
@@ -225,7 +225,7 @@ func TestConfigStructFields(t *testing.T) {
 			NotificationsEnabled: true,
 		},
 		Git: GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 		},
 		Phase: PhaseConfig{
 			Plan: PhaseCommand{

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -4,5 +4,5 @@ const (
 	DefaultWorkflowInterval           = 20
 	DefaultClosedIssueCleanupInterval = 300
 	DefaultTmuxCommandDelay           = 3
-	DefaultWorktreeBasePath           = ".git/soba/worktrees"
+	DefaultWorktreeBasePath           = "/tmp/soba/worktrees"
 )

--- a/internal/config/display_test.go
+++ b/internal/config/display_test.go
@@ -119,7 +119,7 @@ func TestDisplayConfig(t *testing.T) {
 			NotificationsEnabled: true,
 		},
 		Git: GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 		},
 		Phase: PhaseConfig{
 			Plan: PhaseCommand{
@@ -142,7 +142,7 @@ func TestDisplayConfig(t *testing.T) {
 	assert.Contains(t, output, "repository: test/repo")
 	assert.Contains(t, output, "interval: 30")
 	assert.Contains(t, output, "use_tmux: true")
-	assert.Contains(t, output, "worktree_base_path: .git/soba/worktrees")
+	assert.Contains(t, output, "worktree_base_path: /tmp/soba/worktrees")
 
 	// YAML形式であることを確認
 	lines := strings.Split(output, "\n")

--- a/internal/config/template_test.go
+++ b/internal/config/template_test.go
@@ -44,7 +44,7 @@ func TestGenerateTemplate(t *testing.T) {
 		assert.Contains(t, template, "tmux_command_delay: 3")
 		assert.Contains(t, template, "notifications_enabled: false")
 		assert.NotContains(t, template, "setup_workspace")
-		assert.Contains(t, template, "worktree_base_path: .git/soba/worktrees")
+		assert.Contains(t, template, "worktree_base_path: /tmp/soba/worktrees")
 	})
 
 	t.Run("should include environment variable placeholders", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestGenerateTemplate(t *testing.T) {
 		assert.Equal(t, 300, config.Workflow.ClosedIssueCleanupInterval)
 		assert.Equal(t, 3, config.Workflow.TmuxCommandDelay)
 		assert.False(t, config.Slack.NotificationsEnabled)
-		assert.Equal(t, ".git/soba/worktrees", config.Git.WorktreeBasePath)
+		assert.Equal(t, "/tmp/soba/worktrees", config.Git.WorktreeBasePath)
 
 		// Verify phase commands
 		assert.NotNil(t, config.Phase)

--- a/internal/service/daemon_test.go
+++ b/internal/service/daemon_test.go
@@ -42,7 +42,7 @@ func TestNewDaemonServiceWithConfig(t *testing.T) {
 			Interval: 20,
 		},
 		Git: config.GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 		},
 	}
 

--- a/internal/service/git_workspace_test.go
+++ b/internal/service/git_workspace_test.go
@@ -39,7 +39,7 @@ func (m *mockGitClient) WorktreeExists(worktreePath string) bool {
 func TestNewGitWorkspaceManager(t *testing.T) {
 	cfg := &config.Config{
 		Git: config.GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 			BaseBranch:       "main",
 		},
 	}
@@ -60,7 +60,7 @@ func TestGitWorkspaceManager_PrepareWorkspace(t *testing.T) {
 			name:        "Successfully prepare new workspace",
 			issueNumber: 33,
 			setupMocks: func(mc *mockGitClient) {
-				expectedPath := filepath.Join(".git/soba/worktrees", "issue-33")
+				expectedPath := filepath.Join("/tmp/soba/worktrees", "issue-33")
 				mc.On("WorktreeExists", expectedPath).Return(false)
 				mc.On("UpdateBaseBranch", "main").Return(nil)
 				mc.On("CreateWorktree", expectedPath, "soba/33", "main").Return(nil)
@@ -71,7 +71,7 @@ func TestGitWorkspaceManager_PrepareWorkspace(t *testing.T) {
 			name:        "Workspace already exists",
 			issueNumber: 33,
 			setupMocks: func(mc *mockGitClient) {
-				expectedPath := filepath.Join(".git/soba/worktrees", "issue-33")
+				expectedPath := filepath.Join("/tmp/soba/worktrees", "issue-33")
 				mc.On("WorktreeExists", expectedPath).Return(true)
 			},
 			wantErr: false,
@@ -80,7 +80,7 @@ func TestGitWorkspaceManager_PrepareWorkspace(t *testing.T) {
 			name:        "Failed to update base branch",
 			issueNumber: 33,
 			setupMocks: func(mc *mockGitClient) {
-				expectedPath := filepath.Join(".git/soba/worktrees", "issue-33")
+				expectedPath := filepath.Join("/tmp/soba/worktrees", "issue-33")
 				mc.On("WorktreeExists", expectedPath).Return(false)
 				mc.On("UpdateBaseBranch", "main").Return(assert.AnError)
 			},
@@ -90,7 +90,7 @@ func TestGitWorkspaceManager_PrepareWorkspace(t *testing.T) {
 			name:        "Failed to create worktree",
 			issueNumber: 33,
 			setupMocks: func(mc *mockGitClient) {
-				expectedPath := filepath.Join(".git/soba/worktrees", "issue-33")
+				expectedPath := filepath.Join("/tmp/soba/worktrees", "issue-33")
 				mc.On("WorktreeExists", expectedPath).Return(false)
 				mc.On("UpdateBaseBranch", "main").Return(nil)
 				mc.On("CreateWorktree", expectedPath, "soba/33", "main").Return(assert.AnError)
@@ -109,7 +109,7 @@ func TestGitWorkspaceManager_PrepareWorkspace(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
 				Git: config.GitConfig{
-					WorktreeBasePath: ".git/soba/worktrees",
+					WorktreeBasePath: "/tmp/soba/worktrees",
 					BaseBranch:       "main",
 				},
 			}
@@ -140,7 +140,7 @@ func TestGitWorkspaceManager_CleanupWorkspace(t *testing.T) {
 			name:        "Successfully cleanup workspace",
 			issueNumber: 33,
 			setupMocks: func(mc *mockGitClient) {
-				expectedPath := filepath.Join(".git/soba/worktrees", "issue-33")
+				expectedPath := filepath.Join("/tmp/soba/worktrees", "issue-33")
 				mc.On("WorktreeExists", expectedPath).Return(true)
 				mc.On("RemoveWorktree", expectedPath).Return(nil)
 			},
@@ -150,7 +150,7 @@ func TestGitWorkspaceManager_CleanupWorkspace(t *testing.T) {
 			name:        "Workspace does not exist",
 			issueNumber: 33,
 			setupMocks: func(mc *mockGitClient) {
-				expectedPath := filepath.Join(".git/soba/worktrees", "issue-33")
+				expectedPath := filepath.Join("/tmp/soba/worktrees", "issue-33")
 				mc.On("WorktreeExists", expectedPath).Return(false)
 			},
 			wantErr: false,
@@ -159,7 +159,7 @@ func TestGitWorkspaceManager_CleanupWorkspace(t *testing.T) {
 			name:        "Failed to remove worktree",
 			issueNumber: 33,
 			setupMocks: func(mc *mockGitClient) {
-				expectedPath := filepath.Join(".git/soba/worktrees", "issue-33")
+				expectedPath := filepath.Join("/tmp/soba/worktrees", "issue-33")
 				mc.On("WorktreeExists", expectedPath).Return(true)
 				mc.On("RemoveWorktree", expectedPath).Return(assert.AnError)
 			},
@@ -177,7 +177,7 @@ func TestGitWorkspaceManager_CleanupWorkspace(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
 				Git: config.GitConfig{
-					WorktreeBasePath: ".git/soba/worktrees",
+					WorktreeBasePath: "/tmp/soba/worktrees",
 					BaseBranch:       "main",
 				},
 			}
@@ -200,7 +200,7 @@ func TestGitWorkspaceManager_CleanupWorkspace(t *testing.T) {
 func TestGitWorkspaceManager_GetWorkspacePath(t *testing.T) {
 	cfg := &config.Config{
 		Git: config.GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 			BaseBranch:       "main",
 		},
 	}
@@ -215,12 +215,12 @@ func TestGitWorkspaceManager_GetWorkspacePath(t *testing.T) {
 		{
 			name:        "Valid issue number",
 			issueNumber: 33,
-			want:        filepath.Join(".git/soba/worktrees", "issue-33"),
+			want:        filepath.Join("/tmp/soba/worktrees", "issue-33"),
 		},
 		{
 			name:        "Large issue number",
 			issueNumber: 999,
-			want:        filepath.Join(".git/soba/worktrees", "issue-999"),
+			want:        filepath.Join("/tmp/soba/worktrees", "issue-999"),
 		},
 	}
 
@@ -235,7 +235,7 @@ func TestGitWorkspaceManager_GetWorkspacePath(t *testing.T) {
 func TestGitWorkspaceManager_GetBranchName(t *testing.T) {
 	cfg := &config.Config{
 		Git: config.GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 			BaseBranch:       "main",
 		},
 	}
@@ -270,13 +270,13 @@ func TestGitWorkspaceManager_GetBranchName(t *testing.T) {
 func TestGitWorkspaceManager_WithCustomBaseBranch(t *testing.T) {
 	cfg := &config.Config{
 		Git: config.GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 			BaseBranch:       "develop",
 		},
 	}
 	mockClient := new(mockGitClient)
 
-	expectedPath := filepath.Join(".git/soba/worktrees", "issue-42")
+	expectedPath := filepath.Join("/tmp/soba/worktrees", "issue-42")
 	mockClient.On("WorktreeExists", expectedPath).Return(false)
 	mockClient.On("UpdateBaseBranch", "develop").Return(nil)
 	mockClient.On("CreateWorktree", expectedPath, "soba/42", "develop").Return(nil)
@@ -293,13 +293,13 @@ func TestGitWorkspaceManager_PrepareWorkspace_UpdatesBaseBranch(t *testing.T) {
 	// before creating a new worktree, ensuring we have the latest code
 	cfg := &config.Config{
 		Git: config.GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 			BaseBranch:       "main",
 		},
 	}
 	mockClient := new(mockGitClient)
 
-	expectedPath := filepath.Join(".git/soba/worktrees", "issue-100")
+	expectedPath := filepath.Join("/tmp/soba/worktrees", "issue-100")
 
 	// Setup expectations: UpdateBaseBranch must be called before CreateWorktree
 	mockClient.On("WorktreeExists", expectedPath).Return(false)

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -76,7 +76,7 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 			Repository: "test/repo",
 		},
 		Git: config.GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 		},
 		Workflow: config.WorkflowConfig{
 			Interval: 1,

--- a/internal/service/workflow_executor_test.go
+++ b/internal/service/workflow_executor_test.go
@@ -154,7 +154,7 @@ func TestWorkflowExecutor_ExecutePhase(t *testing.T) {
 				tmux.On("CreateWindow", "soba-test-repo", "issue-456").Return(nil)
 				// Window was created, so no pane management
 				tmux.On("GetLastPaneIndex", "soba-test-repo", "issue-456").Return(0, nil)
-				tmux.On("SendCommand", "soba-test-repo", "issue-456", 0, `cd .git/soba/worktrees/issue-456 && echo "Planning"`).Return(nil)
+				tmux.On("SendCommand", "soba-test-repo", "issue-456", 0, `cd /tmp/soba/worktrees/issue-456 && echo "Planning"`).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -176,7 +176,7 @@ func TestWorkflowExecutor_ExecutePhase(t *testing.T) {
 				tmux.On("CreatePane", "soba-test-repo", "issue-789").Return(nil)
 				tmux.On("ResizePanes", "soba-test-repo", "issue-789").Return(nil)
 				tmux.On("GetLastPaneIndex", "soba-test-repo", "issue-789").Return(2, nil) // 送信用（新しいペイン）
-				tmux.On("SendCommand", "soba-test-repo", "issue-789", 2, `cd .git/soba/worktrees/issue-789 && echo "Implementing"`).Return(nil)
+				tmux.On("SendCommand", "soba-test-repo", "issue-789", 2, `cd /tmp/soba/worktrees/issue-789 && echo "Implementing"`).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -226,7 +226,7 @@ func TestWorkflowExecutor_ExecutePhase(t *testing.T) {
 
 			cfg := &config.Config{
 				Git: config.GitConfig{
-					WorktreeBasePath: ".git/soba/worktrees",
+					WorktreeBasePath: "/tmp/soba/worktrees",
 				},
 				GitHub: config.GitHubConfig{
 					Repository: "test/repo",
@@ -356,13 +356,13 @@ func TestWorkflowExecutor_ExecutePhase_WithWorktreePreparation(t *testing.T) {
 	mockTmux.On("CreateWindow", "soba-test-repo", "issue-1").Return(nil)
 	// Window was created, so no pane management
 	mockTmux.On("GetLastPaneIndex", "soba-test-repo", "issue-1").Return(0, nil)
-	mockTmux.On("SendCommand", "soba-test-repo", "issue-1", 0, `cd .git/soba/worktrees/issue-1 && soba:plan "1"`).Return(nil)
+	mockTmux.On("SendCommand", "soba-test-repo", "issue-1", 0, `cd /tmp/soba/worktrees/issue-1 && soba:plan "1"`).Return(nil)
 
 	executor := NewWorkflowExecutor(mockTmux, mockWorkspace, mockProcessor, logging.NewMockLogger())
 
 	cfg := &config.Config{
 		Git: config.GitConfig{
-			WorktreeBasePath: ".git/soba/worktrees",
+			WorktreeBasePath: "/tmp/soba/worktrees",
 		},
 		GitHub: config.GitHubConfig{
 			Repository: "test/repo",
@@ -678,7 +678,7 @@ func TestWorkflowExecutor_PrepareWorkspaceWithBaseBranchUpdate(t *testing.T) {
 
 			cfg := &config.Config{
 				Git: config.GitConfig{
-					WorktreeBasePath: ".git/soba/worktrees",
+					WorktreeBasePath: "/tmp/soba/worktrees",
 					BaseBranch:       "main",
 				},
 				GitHub: config.GitHubConfig{


### PR DESCRIPTION
## Implementation Complete

fixes #154

### 変更内容
- worktreeのデフォルト作成先を `.git/soba/worktrees` から `/tmp/soba/worktrees` に変更
- `DefaultWorktreeBasePath` 定数を更新
- config_template.ymlのデフォルト値を更新
- 全てのテストファイルのパスを新しいデフォルト値に更新

### 背景
- 現在のworktree作成先（.git/soba/worktrees）は、プロジェクトディレクトリ内に作成されるため、Claudeが混乱することがある
- /tmp配下に作成することで、他のプロジェクトとの干渉を防ぎ、より安定した動作を実現

### テスト結果
- 単体テスト: ✅ Pass
  - config関連テスト
  - service関連テスト
  - cli関連テスト（一部タイムアウトするテストあり、ただし今回の変更とは無関係）
- 統合テスト: ✅ Pass

### 注意事項
- 後方互換性の維持は不要（要求仕様に基づく）
- 既存のworktreeは手動での移行が必要
- `/tmp` ディレクトリはOS再起動時にクリアされる可能性があるが、worktree作成時に親ディレクトリを自動作成する仕組みは既に実装済み

### 既知の問題
- TestInitCommandがタイムアウトする問題を発見したが、今回の変更とは無関係（変更前でも再現）
- ghコマンドがインタラクティブモードになっている可能性がある

### チェックリスト
- [x] 実装計画に従った実装
- [x] テストカバレッジの確保
- [x] 既存機能への影響なし